### PR TITLE
Make xslt work again

### DIFF
--- a/src/pyff/pipes/builtins.py
+++ b/src/pyff/pipes/builtins.py
@@ -285,7 +285,7 @@ Publish the working document in XML form.
     - publish: /tmp/idp.xml
     """
 
-    if req.t is None or not len(req.t):
+    if req.t is None:
         raise ValueError("Empty document submitted for publication")
 
     try:


### PR DESCRIPTION
"Fixes" the

```
object of type 'lxml.etree._XSLTResultTree' has no len()
```

error when trying to use any xslt transformation.
