### PR TITLE
Minor typo, whitespace

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,11 @@ for metadata exchange by Ian Young: http://iay.org.uk/blog/2008/10/metadata_inte
 Features 
 ========
 
-* Pluggable "piplines" for processing SAML metadata
+* Pluggable "pipelines" for processing SAML metadata
 * Signature validation and creation
 * Support for using PKCS#11 tokens for signing
 * Certificate expiration checking and reporting
-* Fast parallell fetch of multiple streams
+* Fast parallel fetching of multiple streams
 
 Dependencies
 ============

--- a/src/pyff/xslt/pp.xsl
+++ b/src/pyff/xslt/pp.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:output method="xml" encoding="UTF8"/>
-  <xsl:param name="indent-increment" select="'   '"/>
+  <xsl:param name="indent-increment" select="'  '"/>
   
   <xsl:template name="newline">
     <xsl:text disable-output-escaping="yes">


### PR DESCRIPTION
Minor typo in README.rst
Adjust intendation in pp.xsl to match `xmllint --format`
