### PR TITLE
Update mdx.py

### DIFF
--- a/src/pyff/mdx.py
+++ b/src/pyff/mdx.py
@@ -594,7 +594,7 @@ def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:],
                                    'hP:p:H:CfaA:l:',
-                                   ['help', 'loglevel=', 'log=', 'access-log=', 'error-log=', 'email='
+                                   ['help', 'loglevel=', 'log=', 'access-log=', 'error-log=', 'email=',
                                     'port=', 'host=', 'no-caching', 'autoreload', 'frequency=',
                                     'alias=', 'dir=', 'version', 'proxy'])
     except getopt.error, msg:


### PR DESCRIPTION
Missing comma after 'email=' makes --email and --port arguments unavailable.
