### PR TITLE
pubinfo.xsl misses xml namespace declarations

### DIFF
--- a/src/pyff/xslt/kalmar2.xsl
+++ b/src/pyff/xslt/kalmar2.xsl
@@ -5,7 +5,7 @@
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
                 xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
-		        xmlns:xi="http://www.w3.org/2001/XInclude"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:idpdisco="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol"
                 xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute"
                 xmlns:shibmd="urn:mace:shibboleth:metadata:1.0">

--- a/src/pyff/xslt/pubinfo.xsl
+++ b/src/pyff/xslt/pubinfo.xsl
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi"
   xmlns:date="http://exslt.org/dates-and-times" extension-element-prefixes="date">
 
   <xsl:param name="publisher"/>


### PR DESCRIPTION
This fixes the problem detailed here:
https://groups.google.com/d/msg/pyff-users/L1ZcrZlqxt8/EKdDVm8lew4J

(The change in kalmar2.xsl is purely whitespace, converting 2 tabs to spaces.)
