### PR TITLE
Content of Subject element should be xrd:anyURI

### DIFF
--- a/examples/links.xrd
+++ b/examples/links.xrd
@@ -32,7 +32,7 @@
         </Link>
     </XRD>
     <!-- XRD>
-        <Subject>InCommon</Subject>
+        <Subject>https://incommon.org</Subject>
         <Link rel="urn:oasis:names:tc:SAML:2.0:metadata" href="http://md.incommon.org/InCommon/InCommon-metadata.xml">
             <Title>InCommon Metadata (main aggregate)</Title>
             <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">


### PR DESCRIPTION
According to the xrd-1.0 schema, the content of the Subject element should be xrd:anyURI (a simple extension of xs:anyURI). Rather than repeat the metadata location in the Subject element, the latter is now set to the InCommon registrar ID.
