### PR TITLE
Refactoring for easier WSGI application integration

### DIFF
--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -60,6 +60,7 @@ class Config(object):
     store = pyconfig.setting("pyff.store", None)
     allow_shutdown = pyconfig.setting("pyff.allow_shutdown", False)
     modules = pyconfig.setting("pyff.modules", [])
+    remote_url_cache_dir = pyconfig.setting("pyff.remote_url_cache_dir", ".cache")
 
 
 config = Config()

--- a/src/pyff/utils.py
+++ b/src/pyff/utils.py
@@ -282,11 +282,13 @@ def parse_date(s):
         return datetime.now()
     return datetime(*parsedate(s)[:6])
 
+def cache_filename(uri):
+    return "{}.cache.{}".format(os.getpid(), hashlib.md5(uri).hexdigest())
 
 @retry((IOError, httplib2.HttpLib2Error))
 def load_url(url, enable_cache=True, timeout=60):
     start_time = clock()
-    cache = httplib2.FileCache(".cache")
+    cache = httplib2.FileCache(config.remote_url_cache_dir, safe=cache_filename)
     headers = {'Accept': 'application/samlmetadata+xml,text/xml,application/xml'}
     if not enable_cache:
         headers['cache-control'] = 'no-cache'


### PR DESCRIPTION
Simple refactoring to make it easier to deliver the CherryPy
application as a WSGI application that can be used with other
WSGI servers or frameworks such as mod_wsgi. When used as a WSGI
application configuration is done with a YAML file. The default for the
YAML config file is /etc/pyff/pyff_config.yaml but the name of the file
can be set with the process environment variable PYFF_CONFIG.

To separate runtime from configuration the directory to use for the
cache file for remote URL fetching is now configurable. Further
since the WSGI application may then end up in a multi-process environment
(two more more applications running on the same server) the cache file
name is now derived from the PID and a md5 hash of the remote URL.