### PR TITLE
Update getopts declarations for --module

### DIFF
--- a/src/pyff/md.py
+++ b/src/pyff/md.py
@@ -26,7 +26,7 @@ def main():
     opts = None
     args = None
     try:
-        opts, args = getopt.getopt(sys.argv[1:], 'hRm', ['help', 'loglevel=', 'logfile=', 'version', 'module'])
+        opts, args = getopt.getopt(sys.argv[1:], 'hRm:', ['help', 'loglevel=', 'logfile=', 'version', 'module='])
     except getopt.error as msg:
         print(msg)
         print(__doc__)

--- a/src/pyff/mdx.py
+++ b/src/pyff/mdx.py
@@ -35,7 +35,7 @@ An implementation of draft-lajoie-md-query
             Chdir into <dir> after the server starts up.
     --proxy
             The service is running behind a proxy - respect the X-Forwarded-Host header.
-    -m <module>|--modules=<module>
+    -m <module>|--module=<module>
             Load a module
 
     {pipeline-files}+
@@ -700,7 +700,7 @@ def main():
         opts, args = getopt.getopt(sys.argv[1:],
                                    'hP:p:H:CfaA:l:Rm:',
                                    ['help', 'loglevel=', 'log=', 'access-log=', 'error-log=',
-                                    'port=', 'host=', 'no-caching', 'autoreload', 'frequency=', 'modules=',
+                                    'port=', 'host=', 'no-caching', 'autoreload', 'frequency=', 'module=',
                                     'alias=', 'dir=', 'version', 'proxy', 'allow_shutdown'])
     except getopt.error as msg:
         print(msg)


### PR DESCRIPTION
The getopts optstr declarations in both md.py and mdx.py are inconsistent with their actual use later in the code. Both have option processing that expects an option called --module (singular) with an argument containing the module to load. However:

* md.py has an optstr declaring --module but does not specify that it requires an optarg.
* mdx.py has an optstr declaring --modules (plural) with an optarg but does not process that.

The result is that it is not possible to load a module from the command line in either. This pull request includes separate patches to fix these two problems.

Neither are backwards compatible (specifically, mdx.py doesn't accept --modules) because the previous behaviour resulted in an Unknown option error.