### PR TITLE
Fix for issue 142 'Cannot remove a previously selected IdP...'

### DIFF
--- a/src/pyff/site/static/js/jquery-ds-widget.js
+++ b/src/pyff/site/static/js/jquery-ds-widget.js
@@ -18,6 +18,7 @@ jQuery(function ($) {
         },
 
         _create: function () {
+            console.log("_create is called");
             var obj = this;
             if (typeof obj.options['render'] !== 'function') {
                 obj._template = Hogan.compile('<div data-href="{{entity_id}}" class="identityprovider list-group-item">' +
@@ -132,7 +133,7 @@ jQuery(function ($) {
                 e.preventDefault();
             });
 
-            $('body').on('click', '.cancel', function (e) {
+            $('body').on('click', '.close', function (e) {
                 e.stopPropagation();
                 var entity_element = $(this).closest(obj.selection_selector);
                 var entity_id = entity_element.attr('data-href');

--- a/src/pyff/site/static/js/jquery-ds-widget.js
+++ b/src/pyff/site/static/js/jquery-ds-widget.js
@@ -18,7 +18,6 @@ jQuery(function ($) {
         },
 
         _create: function () {
-            console.log("_create is called");
             var obj = this;
             if (typeof obj.options['render'] !== 'function') {
                 obj._template = Hogan.compile('<div data-href="{{entity_id}}" class="identityprovider list-group-item">' +


### PR DESCRIPTION
Fixes issue 142 'Cannot remove a previously selected IdP from discovery'
by fixing an error in the _update method of the discovery_client widget
defined in the file jquery-ds-widget.js. The error was simply the wrong
CSS class assigned as the selector in a call to .on() to bind the click
event.

### All Submissions:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes? No, there is no test harness for testing GUI functionality.
* [X ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? No, the change was in a Javascript file, not a Python file.


