### PR TITLE
Do not render blank icon for search results

### DIFF
--- a/src/pyff/site/static/js/jquery-ds-widget.js
+++ b/src/pyff/site/static/js/jquery-ds-widget.js
@@ -20,16 +20,26 @@ jQuery(function ($) {
         _create: function () {
             var obj = this;
             if (typeof obj.options['render'] !== 'function') {
-                obj._template = Hogan.compile('<div data-href="{{entity_id}}" class="identityprovider list-group-item">' +
+                obj._template_with_icon = Hogan.compile('<div data-href="{{entity_id}}" class="identityprovider list-group-item">' +
                     '{{^sticky}}<button type="button" alt="{{ _(\"Remove from list\") }}" data-toggle="tooltip" data-placement="left" class="close">&times;</button>{{/sticky}}' +
                     '<div class="media"><div class="d-flex mr-3"><div class="frame-round">' +
+                    '<div class="crop"><img{{#entity_icon}} src="{{entity_icon}}"{{/entity_icon}} data-id={{entity_id}} class="pyff-idp-icon"/></div></div></div>' +
+                    '<div class="media-body"><h5 class="mt-0 mb-1">{{title}}</h5>{{#descr}}{{descr}}{{/descr}}</div>' +
+                    '</div></div>');
+                obj._template_no_icon = Hogan.compile('<div data-href="{{entity_id}}" class="identityprovider list-group-item">' +
+                    '{{^sticky}}<button type="button" alt="{{ _(\"Remove from list\") }}" data-toggle="tooltip" data-placement="left" class="close">&times;</button>{{/sticky}}' +
+                    '<div class="media"><div class="d-flex mr-3"><div class="frame-round" style="visibility: hidden;">' +
                     '<div class="crop"><img{{#entity_icon}} src="{{entity_icon}}"{{/entity_icon}} data-id={{entity_id}} class="pyff-idp-icon"/></div></div></div>' +
                     '<div class="media-body"><h5 class="mt-0 mb-1">{{title}}</h5>{{#descr}}{{descr}}{{/descr}}</div>' +
                     '</div></div>');
 
                 obj.options['render'] = function (item) {
                     item.selection_class = obj.selection_class;
-                    return obj._template.render(item);
+                    if ('entity_icon' in item) {
+                        return obj._template_with_icon.render(item);
+                    } else {
+                        return obj._template_no_icon.render(item);
+                    }
                 }
             }
             if (!$.isFunction(obj.options['render_search_result'])) {


### PR DESCRIPTION
When displaying search results do not render a blank icon. Instead use a
slightly different template that renders with the div containing the
icon having style="visibility: hidden".

Note that a side effect of having two templates and the selection determined by whether the data about the IdP has an 'entity_icon' or not is that for IdPs that do not have any logos in metadata the "preferrred method" display also looks cleaner.

### All Submissions:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes? No, there is no test harness for the Javascript.
* [ X] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? No, there was no change to Python code, only Javascript code.


