### PR TITLE
Fix processing of --frequency option for pyffd executable

### DIFF
--- a/src/pyff/mdx.py
+++ b/src/pyff/mdx.py
@@ -749,7 +749,7 @@ def main():
             elif o in ('--autoreload', '-a'):
                 config.autoreload = True
             elif o in '--frequency':
-                config.frequency = int(a)
+                config.update_frequency = int(a)
             elif o in ('-A', '--alias'):
                 (a, colon, uri) = a.partition(':')
                 assert (colon == ':')


### PR DESCRIPTION
The pyffd executable takes as a command line option --frequency but
without this fix it has no effect since the code parsing the command
line incorrectly sets the attribute on the config object.

### All Submissions:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes? No
* [ X] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


