### PR TITLE
discojson: don't die if favicon unreachable

### DIFF
--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -12,6 +12,7 @@ from itertools import chain
 from copy import deepcopy
 from .exceptions import *
 from six import StringIO
+from requests import ConnectionError
 
 
 class EntitySet(object):
@@ -586,7 +587,10 @@ def discojson(e, langs=None):
             break
 
         if '://' in url:
-            r = url_get(url)
+            try:
+                r = url_get(url)
+            except ConnectionError:
+                continue
             if r.ok and r.content:
                 d['entity_icon'] = img_to_data(r.content, r.headers.get('Content-Type'))
                 break


### PR DESCRIPTION
Sometime eduGAIN favicons throw 404, 403 or other funny things and we get an exception that confuses pyff -- just ignore this stuff and rely on the checks already in place.