### PR TITLE
Have all parsers in parse.py -- fixes #147

### DIFF
--- a/src/pyff/parse.py
+++ b/src/pyff/parse.py
@@ -4,6 +4,7 @@ from .constants import NS
 from .logs import log
 from xmlsec.crypto import CertDict
 from datetime import datetime
+from samlmd import SAMLMetadataResourceParser
 from six import StringIO
 
 __author__ = 'leifj'
@@ -129,7 +130,8 @@ class MDServiceListParser():
         return info
 
 
-_parsers = [XRDParser(), MDServiceListParser(), DirectoryParser('.xml'), NoParser()]
+_parsers = [SAMLMetadataResourceParser(), XRDParser(), MDServiceListParser(), DirectoryParser('.xml'), NoParser()]
+
 
 
 def add_parser(parser):

--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -150,11 +150,6 @@ class SAMLMetadataResourceParser():
         return info
 
 
-from .parse import add_parser
-
-add_parser(SAMLMetadataResourceParser())
-
-
 def metadata_expiration(t):
     relt = root(t)
     if relt.tag in ('{%s}EntityDescriptor' % NS['md'], '{%s}EntitiesDescriptor' % NS['md']):


### PR DESCRIPTION
Avoid spaghetti code among parse.py and samlmd.py .