### PR TITLE
Check for unchanged google-api-key

### DIFF
--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -36,7 +36,7 @@ PLACEHOLDER_ICON = 'data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALA
 DIGESTS = ['sha1', 'md5', 'null']
 
 class Config(object):
-    google_api_key = pyconfig.setting("pyff.google_api_key", "google+api+key+not+set")
+    google_api_key = pyconfig.setting("pyff.google_api_key", None) # Add your own Google Maps API key
     loglevel = pyconfig.setting("pyff.loglevel", logging.INFO)
     access_log = pyconfig.setting("pyff.access_log", None)
     error_log = pyconfig.setting("pyff.error_log", None)


### PR DESCRIPTION
Hmm... I took a look at https://github.com/IdentityPython/pyFF/issues/128 and must say I'm not impressed. The default still is google+api+key+not+set and the template logic only skips inclusion if the key is not set (if key evaluates to false). This means that a vanilla install always triggers the error, which IMHO is far from ideal. If google+api+key+not+set is the default, the template logic should check for the key != "google+api+key+not+set".