### PR TITLE
Fix cleaning of item object

### DIFF
--- a/src/pyff/site/static/js/ds-client.js
+++ b/src/pyff/site/static/js/ds-client.js
@@ -89,6 +89,20 @@
         return new Date().getTime();
     };
 
+    DiscoveryService._clean_item = function(item) {
+        if (item.entity && (item.entity.entity_id || item.entity.entityID) && item.entity.title) {
+            var entity = item.entity;
+            if (entity && entity.entityID && !entity.entity_id) {
+               entity.entity_id = entity.entityID;
+            }
+            if (entity && !entity.entity_icon && entity.icon) {
+               entity.entity_icon = entity.icon;
+            }
+        }
+        
+        return item;
+    }
+
     DiscoveryService.prototype.with_items = function(callback) {
         var obj = this;
         var storage = this.get_storage();
@@ -105,21 +119,13 @@
                 lst = [];
             }
 
-            var clean = {};
+            var cleaned_items = {};
             for (var i = 0; i < lst.length; i++) {
-                if (lst[i].entity && (lst[i].entity.entity_id || lst[i].entity.entityID) && lst[i].entity.title) {
-                    var entity = lst[i].entity;
-                    if (entity && entity.entityID && !entity.entity_id) {
-                       entity.entity_id = entity.entityID;
-                    }
-                    if (entity && !entity.entity_icon && entity.icon) {
-                       entity.entity_icon = entity.icon;
-                    }
-                    clean[entity.entity_id] = lst[i];
-                }
+                var cleaned_item = DiscoveryService._clean_item(lst[i]);
+                cleaned_items[cleaned_item.entity['entity_id']] = cleaned_item;
             }
 
-            lst = Object.values(clean);
+            lst = Object.values(cleaned_items);
 
             while (lst.length > 3) {
                 lst.pop();
@@ -143,6 +149,7 @@
                     return obj.json_mdq_get(id).then(function(entity) {
                         if (entity) {
                             item.entity = entity;
+                            item = DiscoveryService._clean_item(item);
                             item.last_refresh = now;
                         }
                         return item;


### PR DESCRIPTION
The item object passed around includes an entity property, and that
entity property is itself an object that some templates expect to
contain properties entity_id and entity_icon. This commit moves code for
cleaning the item and making sure there are properties entity_id and
entity_icon into a function.

It also applies that function in the logic branch executed when the
cache_time has expired. This fixes an issue where the ra21.html template
expects entity_id and entity_icon and when they are not present due to
the cache expiring the discovery service stops working.

### All Submissions:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes? N/A
* [ ] Does your submission pass tests? N/A
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter? N/A


