### PR TITLE
fix __future__ import

### DIFF
--- a/src/pyff/mdq.py
+++ b/src/pyff/mdq.py
@@ -43,9 +43,9 @@ An implementation of draft-lajoie-md-query
 
 """
 
+from __future__ import unicode_literals
 from .constants import config, parse_options
 from .logs import get_log
-from __future__ import unicode_literals
 import importlib
 import os
 import gunicorn.app.base


### PR DESCRIPTION
This change fixes the following error while compiling bytecode:
  File "/usr/lib/python2.7/site-packages/pyff/mdq.py", line 48
    from .logs import get_log
SyntaxError: from __future__ imports must occur at the beginning of the file

I'm not a python expert, there may be a better correction.