### PR TITLE
More explicit  dependency on python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ here = abspath(dirname(__file__))
 README = open(join(here, 'README.rst')).read()
 NEWS = open(join(here, 'NEWS.txt')).read()
 
+python_requires='>=3.5';
+
 install_requires = [
     'mako',
     'lxml >=4.1.1',
@@ -55,6 +57,10 @@ setup(name='pyFF',
       long_description=README + '\n\n' + NEWS,
       classifiers=[
           # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+         'Programming Language :: Python :: 3',
+         'Programming Language :: Python :: 3.5',
+         'Programming Language :: Python :: 3.6',
+         'Programming Language :: Python :: 3.7',
       ],
       keywords='identity federation saml metadata',
       author=__author__,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ install_requires = [
     'ipaddr',
     'publicsuffix2',
     'redis',
-    'futures',
     'requests',
     'requests_cache',
     'requests_file',


### PR DESCRIPTION
The first commit adds an explicit dependency on python3, as well as classifiers for pipy.

The second commit get rid of a legacy dependency on futures, useless with python 3, and harmful for people installing software using native packaging system instead of using pip.