### PR TITLE
Add timezone argument for IntervalTrigger

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -19,6 +19,7 @@ from lxml import etree
 from pyramid.events import NewRequest
 import requests
 import threading
+import pytz
 
 log = get_log(__name__)
 
@@ -397,6 +398,7 @@ def mkapp(*args, **kwargs):
                                            start_date=start,
                                            seconds=config.update_frequency,
                                            replace_existing=True,
-                                           max_instances=1)
+                                           max_instances=1,
+                                           timezone=pytz.utc)
 
         return ctx.make_wsgi_app()


### PR DESCRIPTION
Since the start_date passed into the
apscheduler.triggers.interval.IntervalTrigger instances is explicitly
using UTC the timezone argument needs to be passed with UTC as a value.
Since apscheduler only supports pytz and not datetime.timezone we pass
in timezone=pytz.utc.

### All Submissions:

* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ X] Have you added an explanation of what problem you are trying to solve with this PR?
* [ X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?

It is not clear there exists any test harness for the scheduler yet.

* [X ] Does your submission pass tests?

The same tests pass before and after this change (there are currently 8 failing on master and the 1.1.1 tag).

* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

The "new" code is not following flake8 yet.


