### PR TITLE
Lowercase query match string for process_handler

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -144,7 +144,7 @@ def process_handler(request):
                      'accept': accepter,
                      'url': request.current_route_url(),
                      'select': q,
-                     'match': match,
+                     'match': match.lower() if match else match,
                      'path': path,
                      'stats': {}}
 


### PR DESCRIPTION
Add logic to lowercase the query text or match string for the
process_handler to make its behavior consistent with the API
search_handler so that a frontend can point at either search URL and
observe the same case behavior.

### All Submissions:

* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?

There does not appear to be a test harness yet for testing the process_handler.

* [ X] Does your submission pass tests?

The same tests pass before and after the change.

* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

The current code base is not following PEP8 at this time.


