### PR TITLE
Prevent error when unpickling RedisWhooshStore from Redis

### DIFF
--- a/src/pyff/store.py
+++ b/src/pyff/store.py
@@ -519,6 +519,7 @@ class RedisWhooshStore(SAMLStoreBase):  # TODO: This needs a gc mechanism for ke
             self.reset()
 
     def _setup(self):
+        self._redis = getattr(self, '_redis', None)
         if not self._redis:
             self._redis = redis()  # XXX test cases won't get correctly unpicked because of this
         self.schema = Schema(content=NGRAMWORDS(stored=False))


### PR DESCRIPTION
When Redis is used as the job store the unpickling of an instance of
RedisWhooshStore throws an AttributeError because self._redis does not
exist when the test to see if self._redis is None is executed. This
patch assigns self._redis to getattr(self, '_redis', None) before the
test and prevents the AttributeError exception from being thrown.

### All Submissions:

* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
There does not appear to be a test harness for APScheduler jobs.

* [ ] Does your submission pass tests?
Current tests fail but the failures appear to not be related to this patch.

* [ X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


