### PR TITLE
Remove md:RoleDescriptor elements

### DIFF
--- a/src/pyff/xslt/tidy.xsl
+++ b/src/pyff/xslt/tidy.xsl
@@ -11,6 +11,7 @@
   <xsl:template match="@cacheDuration"/>
   <xsl:template match="@xml:base"/>
   <xsl:template match="ds:Signature"/>
+  <xsl:template match="md:RoleDescriptor"/>
   <xsl:template match="md:OrganizationName|md:OrganizationURL|md:OrganizationDisplayName">
      <xsl:if test="normalize-space(text()) != ''">
         <xsl:copy><xsl:apply-templates select="node()|@*"/></xsl:copy>


### PR DESCRIPTION
In order to avoid failing XSD schema validation at metadata consumers configured to perform validation, should an entity reference WS-* XSD schemas within (non-SAML) md:RoleDescriptor element but the metadata consumer is lacking a copy of the relevant XSD schema files.

As someone explained on the REFEDS FOG list:

> The reason for this rather harsh treatment is that RoleDescriptor is
> one of the very few places in the SAML schema which doesn't allow
> for lax validation. That means that if you republish this construct
> to your customers, if ANY of them schema-validate, that validation
> will fail unless they have the specific schema available.

This was also discussed on the [edugain-discuss](https://lists.geant.org/sympa/arc/edugain-discuss/2014-11/msg00031.html) [mailing list](https://lists.geant.org/sympa/arc/edugain-discuss/2014-11/msg00032.html) back in 2014 when this issue first appeared.

I've been running with this in prod ever since w/o problems.