### PR TITLE
Replace dash with underscore when matching envvars

### DIFF
--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -95,7 +95,7 @@ class EnvSetting(object):
         self._fallback = pyconfig.setting('pyff.{}'.format(name), default, allow_default=True)
 
     def __get__(self, instance, owner):
-        v = os.environ.get("PYFF_{}".format(self.name.upper().replace('.','_')), self._fallback.__get__(instance, owner))
+        v = os.environ.get("PYFF_{}".format(self.name.upper().replace('.','_').replace('-','_')), self._fallback.__get__(instance, owner))
         if v is not None:
             v = self.typeconv(v)
 


### PR DESCRIPTION
I have not used this myself yet but the code for `PYFF_` environment variables does not quite match the inline documentation which states that:

> Any occurence of '.' or '-' is also transscribed to '_' when the setting is referenced as an environment variable

But so far only dots were replaced but not (also) dashes. This PR also replaces dashes with underscores.