### PR TITLE
Better __delitem__ for LRUProxyDict to prevent IndexError

### DIFF
--- a/src/pyff/utils.py
+++ b/src/pyff/utils.py
@@ -862,8 +862,8 @@ class LRUProxyDict(MutableMapping):
         self._cache[key] = value
 
     def __delitem__(self, key):
-        del self._proxy[key]
-        del self._cache[key]
+        self._proxy.pop(key, None)
+        self._cache.pop(key, None)
 
     def __iter__(self):
         return self._proxy.__iter__()


### PR DESCRIPTION
Use the pop() methods for the LRUCache and redis-collections Dict
classes instead of del to prevent IndexError when the key is missing.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


