### PR TITLE
Add Redis host and port to RedisJobStore

### DIFF
--- a/src/pyff/utils.py
+++ b/src/pyff/utils.py
@@ -827,7 +827,7 @@ def non_blocking_lock(lock=threading.Lock(), exception_class=ResourceException, 
 
 def make_default_scheduler():
     if config.scheduler_job_store == 'redis':
-        jobstore = RedisJobStore()
+        jobstore = RedisJobStore(host=config.redis_host, port=config.redis_port)
     elif config.scheduler_job_store == 'memory':
         jobstore = MemoryJobStore()
     else:


### PR DESCRIPTION
Fix to pass the redis_host and redis_port to the apscheduler
RedisJobStore() instantiation.

### All Submissions:

* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


