### PR TITLE
Better reference to online resources

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,6 @@ python SAML metadata aggregator
 This is a SAML metadata aggregator written in python. It is based on the model 
 for metadata exchange by Ian Young: http://iay.org.uk/blog/2008/10/metadata_interc.html
 
-* http://github.com/IdentityPython/pyFF
-* http://pypi.python.org/pypi/pyFF
-* http://packages.python.org/pyFF
-
 Features 
 ========
 
@@ -48,3 +44,8 @@ Dependencies
 
 * pyXMLSecurity
 * PyKCS11 (optional)
+
+More information
+================
+
+Project homepage: https://pyff.io/


### PR DESCRIPTION
Let's promote the official project homepage, instead of multiple
heterogenous and sometimes obsoletes URLs.


