### PR TITLE
Only use path extension when no Accept header is present

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -140,20 +140,18 @@ def process_handler(request):
         if pfx is None:
             raise exc.exception_response(404)
 
-    ext = _d(path, True)[1]
+    path, ext = _d(path, True)
+    if pfx and path:
+        q = "{%s}%s" % (pfx, path)
+        path = "/%s/%s" % (alias, path)
+    else:
+        q = path
 
     # TODO - sometimes the client sends > 1 accept header value with ','.
     accept = str(request.accept).split(',')[0]
     # import pdb; pdb.set_trace()
     if (not accept or 'application/*' in accept or 'text/*' in accept or '*/*' in accept) and ext:
         accept = _ctypes[ext]
-        path = _d(path, True)[0]
-
-    if pfx and path:
-        q = "{%s}%s" % (pfx, path)
-        path = "/%s/%s" % (alias, path)
-    else:
-        q = path
 
     try:
         accepter = MediaAccept(accept)

--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -140,18 +140,46 @@ def process_handler(request):
         if pfx is None:
             raise exc.exception_response(404)
 
-    path, ext = _d(path, True)
+    # content_negotiation_policy is one of three values:
+    # 1. extension - current default, inspect the path and if it ends in
+    #    an extension, e.g. .xml or .json, always strip off the extension to
+    #    get the entityID and if no accept header or a wildcard header, then
+    #    use the extension to determine the return Content-Type.
+    #
+    # 2. adaptive - only if no accept header or if a wildcard, then inspect
+    #    the path and if it ends in an extension strip off the extension to
+    #    get the entityID and use the extension to determine the return
+    #    Content-Type.
+    #
+    # 3. header - future default, do not inspect the path for an extension and
+    #    use only the Accept header to determine the return Content-Type.
+    policy = config.content_negotiation_policy
+
+    # TODO - sometimes the client sends > 1 accept header value with ','.
+    accept = str(request.accept).split(',')[0]
+    valid_accept = (accept and
+                    not ('application/*' in accept
+                         or 'text/*' in accept
+                         or '*/*' in accept)
+                    )
+
+    path_no_extension, extension = _d(path, True)
+    accept_from_extension = _ctypes.get(extension, accept)
+
+    if policy == 'extension':
+        path = path_no_extension
+        if not valid_accept:
+            accept = accept_from_extension
+    elif policy == 'adaptive':
+        if not valid_accept:
+            path = path_no_extension
+            accept = accept_from_extension
+
     if pfx and path:
         q = "{%s}%s" % (pfx, path)
         path = "/%s/%s" % (alias, path)
     else:
         q = path
-
-    # TODO - sometimes the client sends > 1 accept header value with ','.
-    accept = str(request.accept).split(',')[0]
-    # import pdb; pdb.set_trace()
-    if (not accept or 'application/*' in accept or 'text/*' in accept or '*/*' in accept) and ext:
-        accept = _ctypes[ext]
 
     try:
         accepter = MediaAccept(accept)

--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -140,18 +140,20 @@ def process_handler(request):
         if pfx is None:
             raise exc.exception_response(404)
 
-    path, ext = _d(path, True)
-    if pfx and path:
-        q = "{%s}%s" % (pfx, path)
-        path = "/%s/%s" % (alias, path)
-    else:
-        q = path
+    ext = _d(path, True)[1]
 
     # TODO - sometimes the client sends > 1 accept header value with ','.
     accept = str(request.accept).split(',')[0]
     # import pdb; pdb.set_trace()
     if (not accept or 'application/*' in accept or 'text/*' in accept or '*/*' in accept) and ext:
         accept = _ctypes[ext]
+        path = _d(path, True)[0]
+
+    if pfx and path:
+        q = "{%s}%s" % (pfx, path)
+        path = "/%s/%s" % (alias, path)
+    else:
+        q = path
 
     try:
         accepter = MediaAccept(accept)

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -162,6 +162,7 @@ class Config(object):
     load_icons_async = setting("load_icons_async", False, as_bool)  # this is unstable - apscheduler is unpredictable
     pipeline = setting("pipeline", None)
     scheduler_job_store = setting("scheduler_job_store", "memory", as_string)
+    content_negotiation_policy = setting("content_negotiation_policy", "extension", as_string)
 
     @property
     def base_url(self):


### PR DESCRIPTION
If no Accept header is present or it is one of the wildcards
application/*, text/*, or */* then inspect the request path for
an extension for a hint on what format (e.g., XML or JSON) to return,
but do not inspect the path for an extension when an Accept header
is present and not one of the wildcards.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


