### PR TITLE
Update documentation and examples for content negotiation

### DIFF
--- a/docs/usage/running.rst
+++ b/docs/usage/running.rst
@@ -56,7 +56,7 @@ a basic example:
   - when request:
     - select:
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
             - first
             - finalize:
                 cacheDuration: PT12H
@@ -64,7 +64,7 @@ a basic example:
             - sign:
                 key: sign.key
                 cert: sign.crt
-            - emit application/xml
+            - emit application/samlmetadata+xml
             - break
         - when accept application/json:
             - discojson
@@ -109,7 +109,7 @@ appear to have no parameters, is actually "fed" from the request processing of p
 
 The subsequent calls to `when` implements content negotiation to provide a discojuice and XML version of the 
 metadata depending on what the caller is asking for. This is key to using pyFF as a backend to the thiss.io discovery 
-service for instance.
+service. More than one content type may be specified to accommodate noncompliant MDQ clients.
 
 The rest of the XML "branch" of the pipeline should be pretty easy to understand. First we use the 
 :py:func:`pyff.builtins.first` pipe to ensure that we only return a single EntityDescriptor if our select

--- a/examples/edugain-copy.fd
+++ b/examples/edugain-copy.fd
@@ -18,7 +18,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - pipe:
                  - when path /md/swamid-kalmar-1.0:
                      - xslt:
@@ -34,7 +34,7 @@
              - sign:
                  key: sign.key
                  cert: sign.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - discojson

--- a/examples/edugain-mdq.fd
+++ b/examples/edugain-mdq.fd
@@ -4,7 +4,7 @@
 - when request:
   - select:
   - pipe:
-    - when accept application/xml:
+    - when accept application/samlmetadata+xml application/xml:
       - first
       - finalize:
           cacheDuration: PT12H
@@ -12,7 +12,7 @@
       - sign:
           key: sign.key
           cert: sign.crt
-      - emit application/xml
+      - emit application/samlmetadata+xml
       - break
     - when accept application/json:
       - discojson

--- a/examples/eidas.fd
+++ b/examples/eidas.fd
@@ -16,7 +16,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - xslt:
                  stylesheet: tidy.xsl
              - first
@@ -26,7 +26,7 @@
              - sign:
                  key: sign.key
                  cert: sign.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - discojson

--- a/examples/mdx.fd
+++ b/examples/mdx.fd
@@ -40,7 +40,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - pipe:
                  - when path /md/swamid-kalmar-1.0:
                      - xslt:
@@ -56,7 +56,7 @@
              - sign:
                  key: sign.key
                  cert: sign.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - discojson

--- a/examples/met.mdx
+++ b/examples/met.mdx
@@ -42,7 +42,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - xslt:
                  stylesheet: tidy.xsl
              - pubinfo:
@@ -54,7 +54,7 @@
              - sign:
                  key: default.key
                  cert: default.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - xslt:

--- a/examples/ndn.fd
+++ b/examples/ndn.fd
@@ -18,7 +18,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - xslt:
                  stylesheet: tidy.xsl
              - first
@@ -28,7 +28,7 @@
              - sign:
                  key: sign.key
                  cert: sign.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - discojson

--- a/examples/new-renater.fd
+++ b/examples/new-renater.fd
@@ -6,7 +6,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - xslt:
                  stylesheet: tidy.xsl
              - first
@@ -16,7 +16,7 @@
              - sign:
                  key: sign.key
                  cert: sign.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - discojson

--- a/examples/test.fd
+++ b/examples/test.fd
@@ -26,7 +26,7 @@
 - when request:
     - select
     - pipe:
-        - when accept application/xml:
+        - when accept application/samlmetadata+xml application/xml:
              - pipe:
                  - when path /md/swamid-kalmar-1.0:
                      - xslt:
@@ -41,7 +41,7 @@
              - sign:
                 key: sign.key
                 cert: sign.crt
-             - emit application/xml
+             - emit application/samlmetadata+xml
              - break
         - when accept application/json:
              - discojson


### PR DESCRIPTION
Update documentation and examples so that content negotiation
using the "when accept" builtin demonstrates how to configure
the pyFF wsgi app to accept the application/samlmetadata+xml
content type as required by the SAML MDQ specification, but also accept
application/xml so that the service is generous with what it accepts
since not all MDQ clients are compliant. Also change the emit pipe value
to application/samlmetadata+xml so that the documentation helps leads
deployers to configurations that deliver a compliant MDQ service.

### All Submissions:

* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X ] Have you added an explanation of what problem you are trying to solve with this PR?
* [X ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?

No, documentation change only.

* [ ] Does your submission pass tests?

N/A documentation change only.

* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

No, documentation change only.

