### PR TITLE
distorted logo fix, issue 204

### DIFF
--- a/src/pyff/site/static/css/icon.css
+++ b/src/pyff/site/static/css/icon.css
@@ -26,7 +26,6 @@
 .crop img {
   display: block;
   min-width: 100%;
-  min-height: 100%;
   margin: auto;
   position: absolute;
   top: -100%;


### PR DESCRIPTION
It's a simple CSS line change to prevent logos from distortion. According to the [204 issue](https://github.com/IdentityPython/pyFF/issues/204).