### PR TITLE
Enable huge_tree option for parse_xml

### DIFF
--- a/src/pyff/utils.py
+++ b/src/pyff/utils.py
@@ -555,7 +555,11 @@ def hex_digest(data, hn='sha1'):
 
 
 def parse_xml(io, base_url=None):
-    return etree.parse(io, base_url=base_url, parser=etree.XMLParser(resolve_entities=False, collect_ids=False))
+    return etree.parse(io, base_url=base_url, parser=etree.XMLParser(
+        resolve_entities=False,
+        collect_ids=False,
+        huge_tree=True
+    ))
 
 
 def has_tag(t, tag):


### PR DESCRIPTION
Importing DFN metadata for EduGAIN fails because the provided XML
document triggers a huge input lookup:

   Error parsing http://www.aai.dfn.de/fileadmin/metadata/dfn-aai-edugain+idp-metadata.xml: internal error: Huge input lookup

As metadata can be large quite frequently it seems sensible to enable
this option by default.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


