### PR TITLE
Add makefile with a 'reformat' target to reformat the project using black (and isort).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+SOURCE=		src
+
+reformat:
+	isort --line-width 120 --atomic --project eduid_scimapi --recursive $(SOURCE)
+	black --line-length 120 --target-version py37 --skip-string-normalization $(SOURCE)
+
+typecheck:
+	mypy --ignore-missing-imports $(SOURCE)


### PR DESCRIPTION


If acceptable, please apply this PR and run 'make reformat' and commit the results.

A convenience is to install isort, black and mypy using pipx to have them available everywhere.

To handle different output from different versions of these tools (when developer's installed versions might vary), an idea might be to specify exact versions of them in test_requirements.txt. The ones we currently use in eduID are:

  black==19.10b0
  isort==5.6.4
