### PR TITLE
improve portability and remove redundant set of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,26 @@
-mako
-six
-redis
+accept_types >=0.4.1
+apscheduler
+cachetools
+gunicorn
+httplib2 >=0.7.7
 ipaddr
-lxml
-sphinx-pypi-upload
-sphinx
+iso8601 >=0.1.4
+lxml >=4.1.1
+mako
 nose
-httplib2
-iso8601
-requests
-simplejson
+pyXMLSecurity >=0.15
 pyconfig
-pyyaml
+pyramid
+pyyaml >=3.10
+redis
+redis-collections
+requests
 requests_cache
 requests_file
+simplejson >=2.6.2
+six>=1.11.0
+sphinx
+sphinx-pypi-upload
 whoosh
-accept_types
-pyramid
-six
 wsgi-intercept
-gunicorn
-apscheduler
-redis-collections
-cachetools
 xmldiff

--- a/setup.py
+++ b/setup.py
@@ -2,46 +2,37 @@
 # -*- encoding: utf-8 -*-
 
 from distutils.core import setup
+from pathlib import PurePath
 from platform import python_implementation
 from sys import version_info
 
 from os.path import abspath, dirname, join
+from typing import List
+
 from setuptools import find_packages
 
 __author__ = 'Leif Johansson'
 __version__ = '2.0.0'
 
-here = abspath(dirname(__file__))
-README = open(join(here, 'README.rst')).read()
-NEWS = open(join(here, 'NEWS.txt')).read()
+def load_requirements(path: PurePath) -> List[str]:
+    """ Load dependencies from a requirements.txt style file, ignoring comments etc. """
+    res = []
+    with open(path) as fd:
+        for line in fd.readlines():
+            while line.endswith('\n') or line.endswith('\\'):
+                line = line[:-1]
+            line = line.strip()
+            if not line or line.startswith('-') or line.startswith('#'):
+                continue
+            res += [line]
+    return res
 
-python_requires='>=3.7'
+here = PurePath(__file__)
+README = open(here.with_name('README.rst')).read()
+NEWS = open(here.with_name('NEWS.txt')).read()
 
-install_requires = [
-    'mako',
-    'lxml >=4.1.1',
-    'pyyaml >=3.10',
-    'pyXMLSecurity >=0.15',
-    'iso8601 >=0.1.4',
-    'simplejson >=2.6.2',
-    'httplib2 >=0.7.7',
-    'six>=1.11.0',
-    'ipaddr',
-    'redis-collections',
-    'redis',
-    'requests',
-    'requests_cache',
-    'requests_file',
-    'pyconfig',
-    'pyyaml',
-    'whoosh',
-    'pyramid',
-    'accept_types >=0.4.1',
-    'apscheduler',
-    'cachetools',
-    'xmldiff',
-    'gunicorn'
-]
+install_requires = load_requirements(here.with_name('requirements.txt'))
+tests_require = load_requirements(here.with_name('test_requirements.txt'))
 
 python_implementation_str = python_implementation()
 
@@ -61,7 +52,7 @@ setup(name='pyFF',
       url='https://pyff.io',
       license='BSD',
       setup_requires=['nose>=1.0'],
-      tests_require=['pbr', 'fakeredis>=1.0.5', 'coverage', 'nose>=1.0', 'mock', 'mako', 'testfixtures', 'wsgi_intercept'],
+      tests_require=tests_require,
       test_suite="nose.collector",
       packages=find_packages('src'),
       package_dir={'': 'src'},
@@ -85,4 +76,5 @@ setup(name='pyFF',
           ('**.py', 'python', None),
           ('**/templates/**.html', 'mako', None),
       ]},
-)
+      python_requires='>=3.7',
+      )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,9 +1,10 @@
-setuptools
-pbr
-nose>=1.0
-funcsigs
-mock
-testfixtures
 coverage
-fakeredis
+fakeredis>=1.0.5
+funcsigs
+mako
+mock
+nose>=1.0
+pbr
+setuptools
+testfixtures
 wsgi_intercept


### PR DESCRIPTION
At least the pyXMLSecurity requirement was not present in requirements.txt. Better use the text-files as the canonical source, and load them in setup.py like README.rst and NEWS.txt is loaded.

Using pathlib should be a cross-platform way of dealing with paths and filenames.

Also, I believe python_requires should be passed to setup() and not just declared in setup.py.
