### PR TITLE
time handling fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ cachetools
 gunicorn
 httplib2 >=0.7.7
 ipaddr
-iso8601 >=0.1.4
 lxml >=4.1.1
 mako
 nose

--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -24,7 +24,7 @@ from .pipes import plumbing
 from .repo import MDRepository
 from .resource import Resource
 from .samlmd import entity_display_name
-from .utils import b2u, dumptree, duration2timedelta, hash_id, json_serializer
+from .utils import b2u, dumptree, duration2timedelta, hash_id, json_serializer, utc_now
 
 log = get_log(__name__)
 
@@ -538,8 +538,7 @@ def mkapp(*args, **kwargs):
         ctx.add_route('request', '/*path', request_method='GET')
         ctx.add_view(request_handler, route_name='request')
 
-        start = datetime.utcnow() + timedelta(seconds=1)
-        log.debug(start)
+        start = utc_now() + timedelta(seconds=1)
         if config.update_frequency > 0:
             ctx.registry.scheduler.add_job(
                 call,

--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -407,7 +407,7 @@ def resources_handler(request):
 
 def pipeline_handler(request):
     """
-    Implements the /api/resources endpoint
+    Implements the /api/pipeline endpoint
 
     :param request: the HTTP request
     :return: a JSON representation of the active pipeline

--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -2,6 +2,7 @@ import importlib
 import threading
 from datetime import datetime, timedelta
 from json import dumps
+from typing import Any, List, Mapping
 
 import pkg_resources
 import pyramid.httpexceptions as exc
@@ -21,6 +22,7 @@ from .exceptions import ResourceException
 from .logs import get_log
 from .pipes import plumbing
 from .repo import MDRepository
+from .resource import Resource
 from .samlmd import entity_display_name
 from .utils import b2u, dumptree, duration2timedelta, hash_id, json_serializer
 
@@ -387,7 +389,7 @@ def resources_handler(request):
     :return: a JSON representation of the set of resources currently loaded by the server
     """
 
-    def _info(r):
+    def _info(r: Resource) -> List[Mapping[str, Any]]:
         nfo = r.info
         nfo['Valid'] = r.is_valid()
         nfo['Parser'] = r.last_parser

--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -1524,6 +1524,7 @@ def finalize(req, *opts):
             dt = now + offset
             e.set('validUntil', datetime2iso(dt))
         elif valid_until is not None:
+            # TODO: if validUntil was not present, valid_until will be the string 'None' here - never the literal None
             try:
                 dt = iso2datetime(valid_until)
                 offset = dt - now
@@ -1533,6 +1534,7 @@ def finalize(req, *opts):
 
         # set a reasonable default: 50% of the validity
         # we replace this below if we have cacheDuration set
+        # TODO: offset can be None here, if validUntil is not a valid duration or ISO date
         req.state['cache'] = int(total_seconds(offset) / 50)
 
     cache_duration = req.args.get('cacheDuration', e.get('cacheDuration', None))

--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -17,13 +17,12 @@ from distutils.util import strtobool
 import ipaddr
 import six
 import xmlsec
-from iso8601 import iso8601
 from lxml.etree import DocumentInvalid
 from six.moves.urllib_parse import quote_plus, urlparse
 
 from pyff.pipes import registry
 
-from .constants import NS, config
+from .constants import NS
 from .decorators import deprecated
 from .exceptions import MetadataException
 from .logs import get_log
@@ -42,12 +41,15 @@ from .samlmd import (
     sort_entities,
 )
 from .utils import (
+    datetime2iso,
     dumptree,
     duration2timedelta,
     hash_id,
+    iso2datetime,
     root,
     safe_write,
     total_seconds,
+    utc_now,
     validate_document,
     with_tree,
     xslt_transform,
@@ -1503,7 +1505,7 @@ def finalize(req, *opts):
         if name:
             e.set('Name', name)
 
-    now = datetime.utcnow()
+    now = utc_now()
 
     mdid = req.args.get('ID', 'prefix _')
     if re.match('(\s)*prefix(\s)*', mdid):
@@ -1520,17 +1522,16 @@ def finalize(req, *opts):
         offset = duration2timedelta(valid_until)
         if offset is not None:
             dt = now + offset
-            e.set('validUntil', dt.strftime("%Y-%m-%dT%H:%M:%SZ"))
+            e.set('validUntil', datetime2iso(dt))
         elif valid_until is not None:
             try:
-                dt = iso8601.parse_date(valid_until)
-                dt = dt.replace(tzinfo=None)  # make dt "naive" (tz-unaware)
+                dt = iso2datetime(valid_until)
                 offset = dt - now
-                e.set('validUntil', dt.strftime("%Y-%m-%dT%H:%M:%SZ"))
+                e.set('validUntil', datetime2iso(dt))
             except ValueError as ex:
                 log.error("Unable to parse validUntil: %s (%s)" % (valid_until, ex))
 
-                # set a reasonable default: 50% of the validity
+        # set a reasonable default: 50% of the validity
         # we replace this below if we have cacheDuration set
         req.state['cache'] = int(total_seconds(offset) / 50)
 

--- a/src/pyff/parse.py
+++ b/src/pyff/parse.py
@@ -5,7 +5,7 @@ from xmlsec.crypto import CertDict
 
 from .constants import NS
 from .logs import get_log
-from .utils import find_matching_files, first_text, parse_xml, root, unicode_stream
+from .utils import find_matching_files, parse_xml, root, unicode_stream, utc_now
 
 __author__ = 'leifj'
 
@@ -66,7 +66,7 @@ class DirectoryParser(PyffParser):
 
         resource.never_expires = True
         resource.expire_time = None
-        resource.last_seen = datetime.now()
+        resource.last_seen = utc_now().replace(microsecond=0)
 
         return dict()
 
@@ -98,7 +98,7 @@ class XRDParser(PyffParser):
                     fp = fingerprints[0]
                 log.debug("XRD: {} verified by {}".format(link_href, fp))
                 resource.add_child(link_href, verify=fp)
-        resource.last_seen = datetime.now()
+        resource.last_seen = utc_now().replace(microsecond=0)
         resource.expire_time = None
         resource.never_expires = True
         return info

--- a/src/pyff/pipes.py
+++ b/src/pyff/pipes.py
@@ -2,13 +2,17 @@
 Pipes and plumbing. Plumbing instances are sequences of pipes. Each pipe is called in order to load, select,
 transform, sign or output SAML metadata.
 """
+from __future__ import annotations
 
 import os
 import traceback
+from typing import Any, Dict, Optional
 
 import yaml
+from apscheduler.schedulers.background import BackgroundScheduler
 
 from .logs import get_log
+from .repo import MDRepository
 from .utils import PyffException, is_text, resource_string
 
 log = get_log(__name__)
@@ -202,7 +206,16 @@ class Plumbing(object):
         """
 
         def __init__(
-            self, pl, md, t=None, name=None, args=None, state=None, store=None, scheduler=None, raise_exceptions=True
+            self,
+            pl: Plumbing,
+            md: MDRepository,
+            t=None,
+            name=None,
+            args=None,
+            state: Optional[Dict[str, Any]] = None,
+            store=None,
+            scheduler: Optional[BackgroundScheduler] = None,
+            raise_exceptions: bool = True,
         ):
             if not state:
                 state = dict()
@@ -313,7 +326,7 @@ class Plumbing(object):
         ).process(self)
 
 
-def plumbing(fn):
+def plumbing(fn: str) -> Plumbing:
     """
     Create a new plumbing instance by parsing yaml from the filename.
 

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -3,12 +3,14 @@
 An abstraction layer for metadata fetchers. Supports both synchronous and asynchronous fetchers with cache.
 
 """
+from __future__ import annotations
 
 import os
 from collections import deque
 from copy import deepcopy
 from datetime import datetime
 from threading import Condition, Lock
+from typing import Optional
 
 import requests
 
@@ -17,7 +19,7 @@ from .exceptions import ResourceException
 from .fetch import make_fetcher
 from .logs import get_log
 from .parse import parse_resource
-from .utils import Watchable, hex_digest, img_to_data, non_blocking_lock, url_get
+from .utils import Watchable, hex_digest, img_to_data, non_blocking_lock, url_get, utc_now
 
 requests.packages.urllib3.disable_warnings()
 
@@ -133,9 +135,9 @@ class Resource(Watchable):
         self.t = None
         self.type = "text/plain"
         self.etag = None
-        self.expire_time = None
-        self.never_expires = False
-        self.last_seen = None
+        self.expire_time: Optional[datetime] = None
+        self.never_expires: bool = False
+        self.last_seen: Optional[datetime] = None
         self.last_parser = None
         self._infos = deque(maxlen=config.info_buffer_size)
         self.children = deque()
@@ -223,7 +225,7 @@ class Resource(Watchable):
     def is_expired(self) -> bool:
         if self.never_expires:
             return False
-        now = datetime.now()
+        now = utc_now()
         return self.expire_time is not None and self.expire_time < now
 
     def is_valid(self) -> bool:
@@ -301,7 +303,7 @@ class Resource(Watchable):
             info.update(parse_info)
 
         if self.t is not None:
-            self.last_seen = datetime.now()
+            self.last_seen = utc_now().replace(microsecond=0)
             if self.post and isinstance(self.post, list):
                 for cb in self.post:
                     if self.t is not None:

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -220,13 +220,13 @@ class Resource(Watchable):
             for cn in c.walk():
                 yield cn
 
-    def is_expired(self):
+    def is_expired(self) -> bool:
         if self.never_expires:
             return False
         now = datetime.now()
         return self.expire_time is not None and self.expire_time < now
 
-    def is_valid(self):
+    def is_valid(self) -> bool:
         return not self.is_expired() and self.last_seen is not None and self.last_parser is not None
 
     def add_info(self, info):
@@ -239,7 +239,7 @@ class Resource(Watchable):
                 return
         raise ValueError("Resource {} not present - use add_child".format(r.url))
 
-    def add_child(self, url, **kwargs):
+    def add_child(self, url: str, **kwargs) -> Resource:
         opts = deepcopy(self.opts)
         if 'as' in opts:
             del opts['as']

--- a/src/pyff/test/test_pipeline.py
+++ b/src/pyff/test/test_pipeline.py
@@ -8,7 +8,6 @@ import yaml
 from mako.lookup import TemplateLookup
 from mock import patch
 
-# don't remove this - it only appears unused to static analysis
 from pyff import builtins
 from pyff.exceptions import MetadataException
 from pyff.parse import ParserException
@@ -20,6 +19,9 @@ from pyff.test import ExitException, SignerTestCase
 from pyff.utils import hash_id, parse_xml, resource_filename, root
 
 __author__ = 'leifj'
+
+# The 'builtins' import appears unused to static analysers, ensure it isn't removed
+assert builtins is not None
 
 
 class PipeLineTest(SignerTestCase):

--- a/src/pyff/utils.py
+++ b/src/pyff/utils.py
@@ -19,12 +19,12 @@ import threading
 import time
 import traceback
 from copy import copy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from email.utils import parsedate
 from itertools import chain
 from threading import local
 from time import gmtime, strftime
-from typing import AnyStr, Optional, Union
+from typing import Optional, Union
 
 import iso8601
 import pkg_resources
@@ -48,7 +48,6 @@ from . import __version__
 from .constants import NS, config
 from .exceptions import *
 from .logs import get_log
-
 
 etree.set_default_parser(etree.XMLParser(resolve_entities=False))
 
@@ -79,9 +78,9 @@ def trunc_str(x, l):
     return (x[:l] + '..') if len(x) > l else x
 
 
-def resource_string(name, pfx=None):
+def resource_string(name: str, pfx: Optional[str] = None) -> Optional[Union[str, bytes]]:
     """
-    Attempt to load and return the contents (as a string) of the resource named by
+    Attempt to load and return the contents (as a string, or bytes) of the resource named by
     the first argument in the first location of:
 
     # as name in the current directory
@@ -97,7 +96,7 @@ def resource_string(name, pfx=None):
 
     """
     name = os.path.expanduser(name)
-    data = None
+    data: Optional[Union[str, bytes]] = None
     if os.path.exists(name):
         with io.open(name) as fd:
             data = fd.read()
@@ -141,7 +140,7 @@ def resource_filename(name, pfx=None):
     return None
 
 
-def totimestamp(dt, epoch=datetime(1970, 1, 1)):
+def totimestamp(dt: datetime, epoch=datetime(1970, 1, 1)) -> int:
     epoch = epoch.replace(tzinfo=dt.tzinfo)
 
     td = dt - epoch
@@ -160,21 +159,21 @@ def dumptree(t, pretty_print=False, method='xml', xml_declaration=True):
     )
 
 
-def iso_now():
+def iso_now() -> str:
     """
     Current time in ISO format
     """
     return iso_fmt()
 
 
-def iso_fmt(tstamp=None):
+def iso_fmt(tstamp: Optional[float] = None) -> str:
     """
     Timestamp in ISO format
     """
     return strftime("%Y-%m-%dT%H:%M:%SZ", gmtime(tstamp))
 
 
-def ts_now():
+def ts_now() -> int:
     return int(time.time())
 
 
@@ -350,7 +349,7 @@ def with_tree(elt, cb):
             with_tree(child, cb)
 
 
-def duration2timedelta(period):
+def duration2timedelta(period: str) -> Optional[timedelta]:
     regex = re.compile(
         '(?P<sign>[-+]?)P(?:(?P<years>\d+)[Yy])?(?:(?P<months>\d+)[Mm])?(?:(?P<days>\d+)[Dd])?(?:T(?:(?P<hours>\d+)[Hh])?(?:(?P<minutes>\d+)[Mm])?(?:(?P<seconds>\d+)[Ss])?)?'
     )
@@ -440,7 +439,8 @@ def xslt_transform(t, stylesheet, params=None):
         raise ex
 
 
-def valid_until_ts(elt, default_ts):
+# TODO: Unused function
+def valid_until_ts(elt, default_ts: int) -> int:
     ts = default_ts
     valid_until = elt.get("validUntil", None)
     if valid_until is not None:
@@ -457,7 +457,7 @@ def valid_until_ts(elt, default_ts):
     return ts
 
 
-def total_seconds(dt):
+def total_seconds(dt: Union[datetime, timedelta]) -> float:
     if hasattr(dt, "total_seconds"):
         return dt.total_seconds()
     else:


### PR DESCRIPTION

Writing a test case for the /api/resources endpoint revealed that the timestamps were not time zone aware. Looking deeper into it, it seemed like pyFF could use ISO8601 parsing/formatting capabilities available in Python3 and remove an external dependency.

Added typing annotations as I went looking through the code.
