### PR TITLE
add support for saving and falling back to a local backup copy of metadata streams

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -392,7 +392,7 @@ def resources_handler(request):
     def _infos(resources: Iterator[Resource]) -> List[Mapping[str, Any]]:
         return list(filter(lambda i: 'State' in i and i['State'] is not None, [_info(r) for r in resources]))
 
-    def _info(r: Resource) -> List[Mapping[str, Any]]:
+    def _info(r: Resource) -> Mapping[str, Any]:
         nfo = r.info
         nfo['Valid'] = r.is_valid()
         nfo['Parser'] = r.last_parser

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -185,7 +185,7 @@ class ListSetting(BaseSetting):
 
     def __get__(self, instance, owner):
         if len(self.args) > 0:
-            return self.args[0].__get__(self)
+            return self.args[0].__get__(instance, owner)
         else:
             return None
 
@@ -453,6 +453,13 @@ class Config(object):
     xinclude = S("xinclude", default=True, typeconv=as_bool, info="process xinclude statements?")
 
     logger = S('logger', typeconv=as_string, info="python logger config - overides all other logging directives")
+
+    local_copy_dir = S(
+        'local_copy_dir',
+        typeconv=as_string,
+        info="the directory where local backup copies of metadata is stored",
+        default="/var/run/pyff/backup",
+    )
 
     @property
     def base_url(self):

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -20,6 +20,7 @@ from .exceptions import ResourceException
 from .fetch import make_fetcher
 from .logs import get_log
 from .parse import parse_resource
+from urllib.parse import quote as urlescape
 
 from .utils import (
     Watchable,
@@ -31,7 +32,6 @@ from .utils import (
     resource_string,
     resource_filename,
     safe_write,
-    hash_id,
 )
 
 requests.packages.urllib3.disable_warnings()
@@ -184,7 +184,7 @@ class Resource(Watchable):
 
     @property
     def local_copy_fn(self):
-        return os.path.join(config.local_copy_dir, hash_id(self.url, 'sha256', False))
+        return os.path.join(config.local_copy_dir, urlescape(self.url, True))
 
     @property
     def post(self):

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -308,9 +308,9 @@ class Resource(Watchable):
             return None
 
     def load_resource(self, getter):
-        info = self.add_info()
         data: Optional[str] = None
         status: Optional[int] = None
+        info = self.add_info()
 
         log.debug("Loading resource {}".format(self.url))
 
@@ -348,20 +348,20 @@ class Resource(Watchable):
         if data is None or not len(data) > 0:
             raise ResourceException("Got status={:d} while getting {}".format(r.status_code, self.url))
 
-        if status == 200:
-            self.last_seen = utc_now().replace(microsecond=0)
-            safe_write(self.local_copy_fn, data, True)
-
         info['State'] = 'Fetched'
 
-        return data, info
+        return data, status, info
 
     def parse(self, getter):
-        data, info = self.load_resource(getter)
+        data, status, info = self.load_resource(getter)
         info['State'] = 'Parsing'
         parse_info = parse_resource(self, data)
         if parse_info is not None and isinstance(parse_info, dict):
             info.update(parse_info)
+
+        if status == 200:
+            self.last_seen = utc_now().replace(microsecond=0)
+            safe_write(self.local_copy_fn, data, True)
 
         info['State'] = 'Parsed'
         if self.t is not None:

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -117,7 +117,7 @@ class IconHandler(URLHandler):
             else:
                 self.icon_store.update(url, None, info=dict(exception=exception))
         except BaseException as ex:
-            log.warn(ex)
+            log.warning(ex)
 
 
 class ResourceHandler(URLHandler):
@@ -135,7 +135,7 @@ class ResourceHandler(URLHandler):
                 children = t.parse(lambda u: response)
                 self.i_schedule(children)
         except BaseException as ex:
-            log.warn(ex)
+            log.warning(ex)
             t.info['Exception'] = ex
 
 
@@ -299,11 +299,13 @@ class Resource(Watchable):
         if config.local_copy_dir is None:
             return None
 
+        log.warning(
+            "Got status={:d} while getting {}. Attempting fallback to local copy.".format(r.status_code, self.url)
+        )
         try:
             return resource_string(self.local_copy_fn)
-            log.warn("Got status={:d} while getting {}. Fallback to local copy.".format(r.status_code, self.url))
         except IOError as ex:
-            log.warn(
+            log.warning(
                 "Caught an exception trying to load local backup for {} via {}: {}".format(
                     self.url, self.local_copy_fn, ex
                 )
@@ -315,7 +317,7 @@ class Resource(Watchable):
             try:
                 safe_write(self.local_copy_fn, data, True)
             except IOError as ex:
-                log.warn("unable to save backup copy of {}: {}".format(self.url, ex))
+                log.warning("unable to save backup copy of {}: {}".format(self.url, ex))
 
     def load_resource(self, getter):
         data: Optional[str] = None
@@ -349,7 +351,7 @@ class Resource(Watchable):
 
         except IOError as ex:
             if self.local_copy_fn is not None:
-                log.warn("caught exception from {} - trying local backup: {}".format(self.url, ex))
+                log.warning("caught exception from {} - trying local backup: {}".format(self.url, ex))
                 data = self.load_backup()
                 if data is not None and len(data) > 0:
                     info['Reason'] = "Retrieved from local cache because exception: {}".format(ex)

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -310,7 +310,7 @@ class Resource(Watchable):
             )
             return None
 
-    def save_backup(self):
+    def save_backup(self, data):
         if config.local_copy_dir is not None:
             try:
                 safe_write(self.local_copy_fn, data, True)
@@ -373,7 +373,7 @@ class Resource(Watchable):
 
         if status != 218:  # write backup unless we just loaded from backup
             self.last_seen = utc_now().replace(microsecond=0)
-            self.save_backup()
+            self.save_backup(data)
 
         info['State'] = 'Parsed'
         if self.t is not None:

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -10,7 +10,7 @@ from collections import deque
 from copy import deepcopy
 from datetime import datetime
 from threading import Condition, Lock
-from typing import Optional, Dict
+from typing import Optional, Dict, Mapping, Any
 
 import requests
 
@@ -247,8 +247,8 @@ class Resource(Watchable):
     def is_valid(self) -> bool:
         return not self.is_expired() and self.last_seen is not None and self.last_parser is not None
 
-    def add_info(self) -> Dict:
-        info = dict()
+    def add_info(self) -> Mapping[str, Optional[Any]]:
+        info: Dict[str, Optional[Any]] = dict()
         info['State'] = None
         info['Resource'] = self.url
         self._infos.append(info)
@@ -319,7 +319,7 @@ class Resource(Watchable):
 
     def load_resource(self, getter):
         data: Optional[str] = None
-        status: Optional[int] = None
+        status: int = 500
         info = self.add_info()
 
         log.debug("Loading resource {}".format(self.url))

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -10,7 +10,8 @@ from collections import deque
 from copy import deepcopy
 from datetime import datetime
 from threading import Condition, Lock
-from typing import Optional, Dict, Mapping, Any
+from typing import Optional, Dict, Mapping, Any, Callable, Tuple
+from requests.adapters import Response
 
 import requests
 
@@ -247,8 +248,8 @@ class Resource(Watchable):
     def is_valid(self) -> bool:
         return not self.is_expired() and self.last_seen is not None and self.last_parser is not None
 
-    def add_info(self) -> Mapping[str, Optional[Any]]:
-        info: Dict[str, Optional[Any]] = dict()
+    def add_info(self) -> Dict[str, Any]:
+        info: Dict[str, Any] = dict()
         info['State'] = None
         info['Resource'] = self.url
         self._infos.append(info)
@@ -319,7 +320,7 @@ class Resource(Watchable):
             except IOError as ex:
                 log.warning("unable to save backup copy of {}: {}".format(self.url, ex))
 
-    def load_resource(self, getter):
+    def load_resource(self, getter: Callable[[str], Response]) -> Tuple[Optional[str], int, Dict[str, Any]]:
         data: Optional[str] = None
         status: int = 500
         info = self.add_info()

--- a/src/pyff/test/test_md_api.py
+++ b/src/pyff/test/test_md_api.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 import unittest
 from datetime import datetime, timezone
@@ -10,6 +11,7 @@ from wsgi_intercept.interceptor import RequestsInterceptor, UrllibInterceptor
 from pyff.api import mkapp
 from pyff.test import SignerTestCase
 from pyff.test.test_pipeline import PipeLineTest
+from pyff.constants import config
 
 
 class PyFFAPITest(PipeLineTest):
@@ -141,6 +143,7 @@ class PyFFAPITestResources(PipeLineTest):
     @classmethod
     def setUpClass(cls):
         SignerTestCase.setUpClass()
+        config.local_copy_dir = tempfile.TemporaryDirectory()
         cls.templates = TemplateLookup(directories=[os.path.join(cls.datadir, 'mdx')])
         cls.mdx = tempfile.NamedTemporaryFile('w').name
         # cls.mdx_template = cls.templates.get_template('mdx.fd')
@@ -163,6 +166,8 @@ class PyFFAPITestResources(PipeLineTest):
         SignerTestCase.tearDownClass()
         if os.path.exists(cls.mdx):
             os.unlink(cls.mdx)
+        if os.path.exists(config.local_copy_dir):
+            shutil.rmtree(config.local_copy_dir)
 
     def test_api_resources(self):
         """"""
@@ -182,6 +187,7 @@ class PyFFAPITestResources(PipeLineTest):
                     'HTTP Response Headers': {'Content-Length': 3633},
                     'Status Code': '200',
                     'Reason': None,
+                    'State': 'Ready',
                     'Entities': ['https://idp.example.com/saml2/idp/metadata.php'],
                     'Validation Errors': {},
                     'Expiration Time': data[0]['Expiration Time'],  # '2021-04-14 15:21:33.150742',


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

This is about making a local backup copy of metadata files that parses so we can use it as fallback if something happens to the original URL. Makes pyFF more resilient to network failures etc.
