### PR TITLE
a @pipe decorator that maps opts to pydantic data classes on the fly

### DIFF
--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -268,6 +268,7 @@ def fork(req, *opts):
     return req.t
 
 
+@deprecated(reason="any pipeline has been replace by other behaviour")
 @pipe(name='any')
 def _any(lst, d):
     for x in lst:

--- a/src/pyff/pipes.py
+++ b/src/pyff/pipes.py
@@ -31,6 +31,10 @@ def pipe(*args, **kwargs) -> Callable:
 
         @functools.wraps(f)
         def wrapper_pipe(*iargs, **ikwargs) -> Any:
+            # the 'opts' parameter gets special treatment:
+            # locate the type annotation of 'opts' and if it exists assume it refers to a pydantic dataclass
+            # before propagating the call to the wrapped function replace opts with the pydantic dataclass object
+            # created from the Tuple provided
             opts_type: Optional[Type] = None
             if 'opts' in f.__annotations__:
                 opts_type = f.__annotations__['opts']

--- a/src/pyff/pipes.py
+++ b/src/pyff/pipes.py
@@ -24,6 +24,15 @@ registry = dict()
 
 
 def pipe(*args, **kwargs) -> Callable:
+    """
+    A decorator that registers a function as a pipeline in pyFF. Functions decorated *should* have the
+    following prototype:
+
+    @pipe
+    def foo(req: Plumbing.Request, *opts)
+        pass
+    """
+
     def pipe_decorator(f: Callable) -> Callable:
         if 'name' in kwargs:  # called with the name argument @pipe(name=...) or as @pipe()
             f_name = kwargs.get('name', f.__name__)

--- a/src/pyff/pipes.py
+++ b/src/pyff/pipes.py
@@ -50,28 +50,6 @@ def pipe(*args, **kwargs) -> Callable:
         return pipe_decorator
 
 
-def pipe_old(*args, **kwargs):
-    """
-    Register the decorated function in the pyff pipe registry
-    :param name: optional name - if None, use function name
-    """
-
-    def deco_none(f):
-        return f
-
-    def deco_pipe(f):
-        f_name = kwargs.get('name', f.__name__)
-        registry[f_name] = f
-        return f
-
-    if 1 == len(args):
-        f = args[0]
-        registry[f.__name__] = f
-        return deco_none
-    else:
-        return deco_pipe
-
-
 class PipeException(PyffException):
     pass
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

This is an attempt to make the pipe decorator a bit more typesafe based on a discussion with @fredrikt 
