### PR TITLE
optionally serve up front-end apps for all-in-one scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ localconfig.py
 docs/code
 src/pyff/web
 MANIFEST
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ localconfig.py
 .whoosh
 
 docs/code
+src/pyff/web
+MANIFEST

--- a/npm_modules.txt
+++ b/npm_modules.txt
@@ -1,0 +1,2 @@
+@sunet/mdq-browser@1.0.2
+@theidentityselector/thiss@1.5.0-dev0

--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -487,7 +487,6 @@ class ExtensionPredicate:
 
     def __call__(self, info, request):
         match = info['match']
-        print(match)
         if match[self.segment_name] == '':
             return True
 
@@ -558,23 +557,20 @@ def mkapp(*args, **kwargs):
         if config.mdq_browser is not None and os.path.exists(config.mdq_browser):
             ctx.add_route('mdq_browser_config_json', '/config.json', request_method='GET')
             ctx.add_view(
-                lambda request: json_response({'pyff_apis': True, 'mdq_url': config.base_url}),
+                lambda request: json_response({'pyff_apis': True, 'mdq_url': config.base_url + "/entities/"}),
                 route_name='mdq_browser_config_json',
             )
             ctx.add_route_predicate('ext', ExtensionPredicate)
-            ctx.add_route(
-                'mdq_browser_list', '/list{path:.+}', request_method='GET', ext=('path', '.html', '.css', '.js')
-            )
-            ctx.add_route(
-                'mdq_browser_resources',
-                '/resources{path:.*}',
-                request_method='GET',
-                ext=('path', '.html', '.css', '.js'),
-            )
-            ctx.add_route('mdq_browser', '/{path:.*}', request_method='GET', ext=('path', '.html', '.css', '.js'))
-            ctx.add_view(static_view(config.mdq_browser, use_subpath=False), route_name='mdq_browser')
-            ctx.add_view(static_view(config.mdq_browser, use_subpath=False), route_name='mdq_browser_list')
-            ctx.add_view(static_view(config.mdq_browser, use_subpath=False), route_name='mdq_browser_resources')
+            for uri_part in ('/', '/status', '/list', '/resources', '/about', '/font'):
+                route = 'mdq_browser_{}'.format(uri_part)
+                path = '{:s}{{sep:/?}}{{path:.*}}'.format(uri_part)
+                ctx.add_route(
+                    route,
+                    path,
+                    request_method='GET',
+                    ext=('path', '.html', '.css', '.js', '.ico'),
+                )
+                ctx.add_view(static_view(config.mdq_browser, use_subpath=False), route_name=route)
 
         ctx.add_route('request', '/*path', request_method='GET')
         ctx.add_view(request_handler, route_name='request')

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 from distutils.util import strtobool
-
+from typing import Tuple, Union, Any
 import pyconfig
 import six
 
@@ -523,12 +523,12 @@ class Config(object):
 config = Config()
 
 
-def opt_eq_split(s: str) -> str:
+def opt_eq_split(s: str) -> Tuple[Any, Any]:
     for sep in [':', '=']:
         d = tuple(s.rsplit(sep))
         if len(d) == 2:
-            return d
-    return (None, None)
+            return d[0], d[1]
+    return None, None
 
 
 def parse_options(program, docs):

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -462,6 +462,7 @@ class Config(object):
     )
 
     mdq_browser = S('mdq_browser', typeconv=as_string, info="the directory where mdq-browser can be found")
+    thiss = S('thiss', typeconv=as_string, info="the directory where thiss-js can be found")
 
     @property
     def base_url(self):

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -259,9 +259,10 @@ class Config(object):
     google_api_key = S("google_api_key", deprecated=True)
     caching_delay = S("caching_delay", default=300, typeconv=as_int, short='D', deprecated=True)
     proxy = S("proxy", default=False, typeconv=as_bool, deprecated=True)
-    public_url = S("public_url", typeconv=as_string, deprecated=True)
     allow_shutdown = S("allow_shutdown", default=False, typeconv=as_bool, deprecated=True)
     ds_template = S("ds_template", default="ds.html", deprecated=True)
+
+    public_url = S("public_url", typeconv=as_string, info="the public URL of the service - not often needed")
 
     loglevel = S("loglevel", default=logging.WARN, info="set the loglevel")
 
@@ -460,6 +461,8 @@ class Config(object):
         info="the directory where local backup copies of metadata is stored",
         default="/var/run/pyff/backup",
     )
+
+    mdq_browser = S('mdq_browser', typeconv=as_string, info="the directory where mdq-browser can be found")
 
     @property
     def base_url(self):

--- a/src/pyff/mdq.py
+++ b/src/pyff/mdq.py
@@ -51,6 +51,7 @@ def main():
         'workers': config.worker_pool_size,
         'loglevel': config.loglevel,
         'preload_app': True,
+        'env': config.environ,
         'daemon': config.daemonize,
         'capture_output': False,
         'timeout': config.worker_timeout,

--- a/src/pyff/resource.py
+++ b/src/pyff/resource.py
@@ -264,7 +264,7 @@ class Resource(Watchable):
 
     @property
     def post(
-        self,
+            self,
     ) -> Iterable[Callable]:  # TODO: move classes to make this work -> List[Union['Lambda', 'PipelineCallback']]:
         return self.opts.via
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

Back in 1.x pyFF had build-in frontend apps for discovery and metadata visualization. These have since been made into separate projects. In order to enable simple "all in one" deployment scenarios this PR attempts to make it possible for pyffd to serve frontend apps from the embedded gunicorn server. This will not be the default but it will make it possible to launch pyffd with the same feature-set as during 1.x



