### PR TITLE
Switch to ipaddress

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ apscheduler
 cachetools
 gunicorn
 httplib2 >=0.7.7
-ipaddr
 lxml >=4.1.1
 mako
 pyXMLSecurity >=0.15

--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from distutils.util import strtobool
 from typing import Dict, Optional
 
-import ipaddr
+import ipaddress
 import six
 import xmlsec
 from lxml.etree import DocumentInvalid
@@ -790,7 +790,7 @@ def select(req: Plumbing.Request, *opts):
             return [item for item in lst if item is not None]
 
         def _ip_networks(elt):
-            return [ipaddr.IPNetwork(x.text) for x in elt.iter('{%s}IPHint' % NS['mdui'])]
+            return [ipaddress.ip_network(x.text) for x in elt.iter('{%s}IPHint' % NS['mdui'])]
 
         def _match(q, elt):
             q = q.strip()
@@ -798,9 +798,9 @@ def select(req: Plumbing.Request, *opts):
                 try:
                     nets = _ip_networks(elt)
                     for net in nets:
-                        if ':' in q and ipaddr.IPv6Address(q) in net:
+                        if ':' in q and ipaddress.IPv6Address(q) in net:
                             return net
-                        if '.' in q and ipaddr.IPv4Address(q) in net:
+                        if '.' in q and ipaddress.IPv4Address(q) in net:
                             return net
                 except ValueError:
                     pass

--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -798,9 +798,7 @@ def select(req: Plumbing.Request, *opts):
                 try:
                     nets = _ip_networks(elt)
                     for net in nets:
-                        if ':' in q and ipaddress.IPv6Address(q) in net:
-                            return net
-                        if '.' in q and ipaddress.IPv4Address(q) in net:
+                        if ipaddress.ip_adress(q) in net:
                             return net
                 except ValueError:
                     pass

--- a/src/pyff/store.py
+++ b/src/pyff/store.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from threading import ThreadError
 
-import ipaddr
+import ipaddress
 import six
 from cachetools.func import ttl_cache
 from redis_collections import Dict, Set
@@ -421,7 +421,7 @@ class SAMLStoreBase(object):
             return [item for item in lst if item is not None]
 
         def _ip_networks(elt):
-            return [ipaddr.IPNetwork(x.text) for x in elt.iter('{%s}IPHint' % NS['mdui'])]
+            return [ipaddress.ip_network(x.text) for x in elt.iter('{%s}IPHint' % NS['mdui'])]
 
         def _match(qq, elt):
             for q in qq:
@@ -430,9 +430,9 @@ class SAMLStoreBase(object):
                     try:
                         nets = _ip_networks(elt)
                         for net in nets:
-                            if ':' in q and ipaddr.IPv6Address(q) in net:
+                            if ':' in q and ipaddress.IPv6Address(q) in net:
                                 return net
-                            if '.' in q and ipaddr.IPv4Address(q) in net:
+                            if '.' in q and ipaddress.IPv4Address(q) in net:
                                 return net
                     except ValueError:
                         pass

--- a/src/pyff/store.py
+++ b/src/pyff/store.py
@@ -430,9 +430,7 @@ class SAMLStoreBase(object):
                     try:
                         nets = _ip_networks(elt)
                         for net in nets:
-                            if ':' in q and ipaddress.IPv6Address(q) in net:
-                                return net
-                            if '.' in q and ipaddress.IPv4Address(q) in net:
+                            if ipaddress.ip_address(q) in net:
                                 return net
                     except ValueError:
                         pass


### PR DESCRIPTION
ipaddr library has been superseded by ipaddress from standard library:
https://github.com/google/ipaddr-py


