### PR TITLE
Allow multi-word search query strings

### DIFF
--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -805,10 +805,10 @@ def select(req: Plumbing.Request, *opts):
 
             if q is not None and len(q) > 0:
                 tokens = _strings(elt)
+                p = re.compile(r'\b{}'.format(q), re.IGNORECASE)
                 for tstr in tokens:
-                    for tpart in tstr.split():
-                        if tpart.lower().startswith(q):
-                            return tstr
+                    if p.search(tstr):
+                        return tstr
             return None
 
         log.debug("matching {} in {} entities".format(match, len(entities)))


### PR DESCRIPTION
Replace split() / startswith() strategy with regular expression search that anchors on a word boundary.
This is a suggested fix for https://github.com/IdentityPython/pyFF/issues/231

Being unaware of requirements that were used for the prior implementation, I'm using a search pattern that anchors the match on the beginning of a word boundary (/b) with the assumption that the user interface shouldn't get all matches, but rather just those where the query string starts with a letters at the beginning of a word.

Using this regular expression seems like the most straightforward approach. I haven't performed any comparative timing between it, and iterating over the split() / lower().startswith() code it replaces. In my unscientific tests, the search results are returned quickly enough. 


