### PR TITLE
respect querystring when caching GET requests

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -141,7 +141,7 @@ def request_handler(request: Request) -> Response:
     :param request: the HTTP request object
     :return: the data to send to the client
     """
-    key = request.path
+    key = request.path_qs
     r = None
     try:
         r = request.registry.cache[key]


### PR DESCRIPTION
Currently caching of GET requests only considers the url path.
This PR changes the cache key to also contain the query string.

Reason:
I am using thiss-js as identity selector, which submits GET requests with the search string as a query string parameter:

E.g.:
`curl 'https://bach-id-mdq.wu.ac.at/entities/?q=wirtschaftsuni' -H 'Accept: application/json'`
`curl 'https://bach-id-mdq.wu.ac.at/entities/?q=tuwien' -H 'Accept: application/json'`

Without considering the query string, the first request will be cached and the second will request will return a wrong result.

Cheers,
--leo