### PR TITLE
Fix type of seed to the random number generator

### DIFF
--- a/src/pyff/repo.py
+++ b/src/pyff/repo.py
@@ -14,7 +14,7 @@ class MDRepository:
     """A class representing a set of SAML metadata and the resources from where this metadata was loaded."""
 
     def __init__(self, scheduler=None) -> None:
-        random.seed(self)
+        random.seed(id(self))
         self.rm = Resource(url=None, opts=ResourceOpts())  # root
         if scheduler is None:
             scheduler = make_default_scheduler()


### PR DESCRIPTION
Since Python 3.11 the seed given to the `random.seed()` function must be one of the following types: NoneType, int, float, str, bytes, or bytearray.

Reference: https://docs.python.org/3.11/library/random.html#random.seed

When using `self` as the seed, the random part is the memory address of the object, which is equivalent to its identity. Using the identity (an int) should have the same effect in terms of entropy.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?