### PR TITLE
Fix thread liveness check in tests

### DIFF
--- a/src/pyff/test/test_rwlock.py
+++ b/src/pyff/test/test_rwlock.py
@@ -96,7 +96,7 @@ class TestReadWriteLock(TestCase):
             self.exceptions[current_thread().name] = ex
 
     def _raise(self, t):
-        assert not t.isAlive()
+        assert not t.is_alive()
         if t.name in self.exceptions:
             raise self.exceptions[t.name]
 


### PR DESCRIPTION
`threading.Thread.isAlive` is a method carried over from Python 2. In Python 3 it is deprecated and instead `threading.Thread.is_alive` should be used.

Since Python 3.9 the `isAlive` method is removed.