### PR TITLE
Filter results using SP trust information

### DIFF
--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -14,7 +14,6 @@ from copy import deepcopy
 from datetime import datetime
 from str2bool import str2bool
 from typing import Dict, Optional
-
 import ipaddress
 import six
 import xmlsec
@@ -30,6 +29,7 @@ from pyff.pipes import PipeException, PipelineCallback, Plumbing, pipe, registry
 from pyff.samlmd import (
     annotate_entity,
     discojson_t,
+    tinfojson_t,
     entitiesdescriptor,
     find_in_document,
     iter_entities,
@@ -956,6 +956,67 @@ def _discojson(req: Plumbing.Request, *opts):
 
     res = discojson_t(req.t, icon_store=req.md.icon_store)
     res.sort(key=operator.itemgetter('title'))
+
+    return json.dumps(res)
+
+
+@pipe(name='tinfojson')
+def _tinfojson(req, *opts):
+    """
+
+    Return a json representation of the trust information
+
+    .. code-block:: yaml
+      tinfojson:
+
+    The returned json doc will have the following structure.
+
+    The root is a dictionary, in which the keys are the entityID's
+    of the SP entities that have trust information in their metadata,
+    and the values are a representation of that trust information.
+
+    For the XML structure of the trust information see the XML Schema
+    in this repo at `/src/pyff/schema/saml-metadata-trustinfo-v1.0.xsd`.
+
+    For each SP with trust information, the representation of
+    that information is as follows.
+
+    If there are MetadataSource elements, there will be a key
+    'extra_md' pointing to a dictionary of the metadata from those additional
+    sources, with entityIDs as keys and entities (with the format provided by
+    the discojson function above) as values.
+
+    Then there will be a key 'profiles' pointing to a dictionary
+    in which the keys are the names of the trust profiles, and the values
+    are json representations of those trust profiles.
+
+    Each trust profile will have the following keys.
+
+    If the trust profile includes a FallbackHandler element, there will
+    be a key 'fallback_handler' pointing to a dict with 2 keys, 'profile'
+    which by default is 'href', and handler which is a string, commonly a URL.
+
+    Then there will be an 'entity' key pointing to a list of representations of
+    individual trusted/untrusted entities, each of them a dictionary, with 2 keys:
+    'entity_id' pointing to a string with the entityID, and 'include',
+    pointing to a boolean.
+
+    Finally there will be a key 'entities' pointing to a list of representations
+    of groups of trusted/untrusted entities, each of them a dictionary with 3 keys:
+    a 'match' key pointing to the property of the entities by which they will be selected,
+    by default 'registrationAuthority', a key 'select' with the value that will be used
+    to select the 'match' property, and 'include', pointing to a boolean.
+
+    :param req: The request
+    :param opts: Options (unusued)
+    :return: returns a JSON doc
+
+    """
+
+    if req.t is None:
+        raise PipeException("Your pipeline is missing a select statement.")
+
+    res = tinfojson_t(req.t)
 
     return json.dumps(res)
 

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -36,6 +36,7 @@ NS = dict(
     xsi="http://www.w3.org/2001/XMLSchema-instance",
     ser="http://eidas.europa.eu/metadata/servicelist",
     eidas="http://eidas.europa.eu/saml-extensions",
+    ti="urn:oasis:names:tc:SAML:metadata:trustinfo",
 )
 
 #: These are the attribute aliases pyFF knows about. These are used to build URI paths, populate the index

--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -11,6 +11,7 @@ from lxml.builder import ElementMaker
 from lxml.etree import DocumentInvalid, Element, ElementTree
 from pydantic import Field
 from xmlsec.crypto import CertDict
+from .resource import Resource, ResourceHandler
 
 from pyff.constants import ATTRS, NF_URI, NS, config
 from pyff.exceptions import *
@@ -697,6 +698,11 @@ def entity_extended_display_i18n(entity, default_lang=None):
     return name_dict, desc_dict
 
 
+def registration_authority(entity):
+    regauth_el = entity.find(".//{%s}RegistrationInfo" % NS['mdrpi'])
+    return regauth_el.attrib.get('registrationAuthority')
+
+
 def entity_extended_display(entity, langs=None):
     """Utility-method for computing a displayable string for a given entity.
 
@@ -785,6 +791,7 @@ def discojson(e, langs=None, fallback_to_favicon=False, icon_store=None):
     title, descr = entity_extended_display(e)
     entity_id = e.get('entityID')
     title_langs, descr_langs = entity_extended_display_i18n(e)
+    registrationAuthority = registration_authority(e)
 
     d = dict(
         title=title,
@@ -794,6 +801,7 @@ def discojson(e, langs=None, fallback_to_favicon=False, icon_store=None):
         auth='saml',
         entity_id=entity_id,
         entityID=entity_id,
+        registrationAuthority=registrationAuthority
     )
 
     eattr = entity_attribute_dict(e)
@@ -837,6 +845,89 @@ def discojson(e, langs=None, fallback_to_favicon=False, icon_store=None):
 
 def discojson_t(t, icon_store=None):
     return [discojson(en, icon_store=icon_store) for en in iter_entities(t)]
+
+
+def fetch_mdjson(urls):
+    resource = Resource()
+    for url in urls:
+        resource.add_child(url)
+
+    rp = ResourceHandler(name="Metadata")
+    rp.schedule(resource.children)
+    try:
+        rp.done.acquire()
+        rp.done.wait()
+    finally:
+        rp.done.release()
+    rp.fetcher.stop()
+    rp.fetcher.join()
+
+    entities = []
+    for child in resource.children:
+        entities.extend(child.t.findall(".//{%s}EntityDescriptor" % NS['md']))
+
+    ot = entitiesdescriptor(entities, 'extra-sources')
+
+    entities_json_list = discojson_t(ot)
+
+    entities_json = {}
+    for e in entities_json_list:
+        entities_json[e['entityID']] = e
+
+    return entities_json
+
+
+def tinfojson(e):
+    tinfo = {}
+
+    tinfo_el = e.find('.//{%s}TrustInfo' % NS['ti'])
+    if tinfo_el is None:
+        return None
+
+    tinfo['entityID'] = e.get('entityID', None)
+
+    # grab metadata sources, download metadata, and translate to json
+    md_source_urls = [el.text for el in tinfo_el.findall('.//{%s}MetadataSource' % NS['ti'])]
+    if len(md_source_urls) > 0:
+        tinfo['extra_md'] = fetch_mdjson(md_source_urls)
+
+    tinfo['profiles'] = {}
+    # Grab trust profile emements, and translate to json
+    for profile_el in tinfo_el.findall('.//{%s}TrustProfile' % NS['ti']):
+        name = profile_el.attrib['name']
+        tinfo['profiles'][name] = {'entity': [], 'entities': []}
+
+        fallback_handler = tinfo_el.find('.//{%s}FallbackHandler' % NS['ti'])
+        if fallback_handler is not None:
+            prof = fallback_handler.attrib.get('profile', 'href')
+            handler = fallback_handler.text
+            tinfo['profiles'][name]['fallback_handler'] = {'profile': prof, 'handler': handler}
+
+        for entity_el in profile_el.findall('.//{%s}TrustedEntity' % NS['ti']):
+            entity_id = entity_el.text
+            include = entity_el.attrib.get('include', True)
+            include = include if type(include) is bool else include in ('t', 'T', 'true', 'True')
+            tinfo['profiles'][name]['entity'].append({'entity_id': entity_id, 'include': include})
+
+        for entities_el in profile_el.findall('.//{%s}TrustedEntities' % NS['ti']):
+            select = entities_el.text
+            match = entities_el.attrib.get('match', 'registrationAuthority')
+            include = entities_el.attrib.get('include', True)
+            include = include if type(include) is bool else include in ('t', 'T', 'true', 'True')
+            tinfo['profiles'][name]['entities'].append({'select': select, 'match': match, 'include': include})
+
+    return tinfo
+
+
+def tinfojson_t(t):
+    d = []
+
+    for e in iter_entities(t):
+        tinfo = tinfojson(e)
+        if tinfo is not None:
+            d.append(tinfo)
+
+    return d
 
 
 def sha1_id(e):

--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -889,7 +889,10 @@ def tinfojson(e):
     # grab metadata sources, download metadata, and translate to json
     md_source_urls = [el.text for el in tinfo_el.findall('.//{%s}MetadataSource' % NS['ti'])]
     if len(md_source_urls) > 0:
-        tinfo['extra_md'] = fetch_mdjson(md_source_urls)
+        try:
+            tinfo['extra_md'] = fetch_mdjson(md_source_urls)
+        except Exception as e:
+            raise ValueError(f"Problem interpreting metadata at {md_source_urls}: {e}")
 
     tinfo['profiles'] = {}
     # Grab trust profile emements, and translate to json

--- a/src/pyff/schema/saml-metadata-trustinfo-v1.0.xsd
+++ b/src/pyff/schema/saml-metadata-trustinfo-v1.0.xsd
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema  
+ targetNamespace="urn:oasis:names:tc:SAML:metadata:trustinfo"
+ xmlns="http://www.w3.org/2001/XMLSchema"
+ xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"
+ xmlns:ti="urn:oasis:names:tc:SAML:metadata:trustinfo"
+ elementFormDefault="unqualified"
+ attributeFormDefault="unqualified"
+ blockDefault="substitution"
+ version="1.0">
+
+ <annotation>
+   <documentation>
+     Document title: Metadata Extension Schema for SAML V2.0 Metadata Extensions for Trust Information 1.0
+     Document identifier: metadata-trustinfo-v1.0.xsd
+     Location: http://docs.oasis-open.org/security/saml/Post2.0/
+     Revision history:
+   </documentation>
+ </annotation>
+
+ <import namespace="urn:oasis:names:tc:SAML:2.0:metadata"
+   schemaLocation="saml-schema-metadata-2.0.xsd"/>
+ <import namespace="http://www.w3.org/XML/1998/namespace"
+   schemaLocation="xml.xsd"/>
+
+ <element name="TrustInfo" type="ti:TrustInfoType"/>
+ <complexType name="TrustInfoType">
+   <sequence>
+     <element ref="ti:MetadataSource" minOccurs="0" maxOccurs="unbounded"/>
+     <element ref="ti:TrustProfile" minOccurs="0" maxOccurs="unbounded"/>
+     <element ref="ti:TrustProfileRef" minOccurs="0" maxOccurs="unbounded"/>
+   </sequence>
+ </complexType>
+
+ <element name="MetadataSource" type="anyURI"/>
+
+ <element name="TrustProfileRef" type="anyURI"/>
+
+ <element name="TrustProfile" type="ti:TrustProfileType"/>
+ <complexType name="TrustProfileType">
+    <sequence minOccurs="0">
+       <element ref="ti:DisplayName" minOccurs="0" maxOccurs="unbounded"/>
+       <element ref="ti:FallbackHandler" minOccurs="0" maxOccurs="1"/>
+       <element ref="ti:TrustedEntity" minOccurs="0" maxOccurs="unbounded"/>
+       <element ref="ti:TrustedEntities" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="name" type="string" use="required"/>
+    <attribute name="strict" type="boolean" default="false"/>
+ </complexType>
+
+ <element name="DisplayName" type="md:localizedNameType"/>
+
+ <element name="FallbackHandler" type="ti:FallbackHandlerType"/>
+ <complexType name="FallbackHandlerType">
+    <simpleContent>
+      <extension base="anyURI">
+        <attribute name="profile" type="string" default="href"/>
+      </extension>
+    </simpleContent>
+ </complexType>
+
+ <element name="TrustedEntity" type="ti:TrustedEntityType"/>
+ <complexType name="TrustedEntityType">
+    <simpleContent>
+      <extension base="anyURI">
+        <attribute name="include" type="boolean" default="true"/> 
+      </extension>
+    </simpleContent>
+ </complexType>
+ 
+ <element name="TrustedEntities" type="ti:TrustedEntitiesType"/>
+ <complexType name="TrustedEntitiesType">
+    <simpleContent>
+      <extension base="anyURI">
+        <attribute name="match" type="string" default="registrationAuthority"/>
+        <attribute name="include" type="boolean" default="true"/>
+      </extension>
+    </simpleContent>
+ </complexType>  
+
+</schema>

--- a/src/pyff/schema/schema.xsd
+++ b/src/pyff/schema/schema.xsd
@@ -13,4 +13,5 @@
 <import namespace="http://www.w3.org/2005/Atom" schemaLocation="atom.xsd"/>
 <import namespace="http://docs.oasis-open.org/ns/xri/xrd-1.0" schemaLocation="xrd-1.0-os.xsd"/>
 <import namespace="urn:oasis:names:tc:SAML:metadata:rpi" schemaLocation="saml-metadata-rpi-v1.0.xsd"/>
+<import namespace="urn:oasis:names:tc:SAML:metadata:trustinfo" schemaLocation="saml-metadata-trustinfo-v1.0.xsd"/>
 </schema>

--- a/src/pyff/test/data/metadata/test02-sp.xml
+++ b/src/pyff/test/data/metadata/test02-sp.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui" xmlns:mdattr="urn:oasis:names:tc:SAML:metadata:attribute" xmlns:mdrpi="urn:oasis:names:tc:SAML:metadata:rpi" xmlns:shibmd="urn:mace:shibboleth:metadata:1.0" xmlns:xrd="http://docs.oasis-open.org/ns/xri/xrd-1.0" xmlns:pyff="http://pyff.io/NS" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ser="http://eidas.europa.eu/metadata/servicelist" xmlns:eidas="http://eidas.europa.eu/saml-extensions" xmlns:alg="urn:oasis:names:tc:SAML:metadata:algsupport" xmlns:samla="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:init="urn:oasis:names:tc:SAML:profiles:SSO:request-init" xmlns:idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" xmlns:wayf="http://sdss.ac.uk/2006/06/WAYF" xmlns:req-attr="urn:oasis:names:tc:SAML:protcol:ext:req-attr" entityID="https://example.com.com/shibboleth">
+  <md:Extensions>
+    <mdrpi:RegistrationInfo registrationAuthority="http://www.swamid.se/" registrationInstant="2021-06-18T15:55:50Z">
+      <mdrpi:RegistrationPolicy xml:lang="en">http://swamid.se/policy/mdrps</mdrpi:RegistrationPolicy>
+    </mdrpi:RegistrationInfo>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha224"/>
+    <alg:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha512"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha224"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2009/xmldsig11#dsa-sha256"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha1"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+    <alg:SigningMethod Algorithm="http://www.w3.org/2000/09/xmldsig#dsa-sha1"/>
+    <mdattr:EntityAttributes>
+      <saml:Attribute NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" Name="http://macedir.org/entity-category">
+        <saml:AttributeValue>http://www.geant.net/uri/dataprotection-code-of-conduct/v1</saml:AttributeValue>
+        <saml:AttributeValue>https://refeds.org/category/code-of-conduct/v2</saml:AttributeValue>
+      </saml:Attribute>
+    </mdattr:EntityAttributes>
+  </md:Extensions>
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <md:Extensions>
+      <mdui:UIInfo>
+        <mdui:DisplayName xml:lang="sv">exampleService (ExampleOrg)</mdui:DisplayName>
+        <mdui:DisplayName xml:lang="en">exampleService (ExampleOrg)</mdui:DisplayName>
+        <mdui:Description xml:lang="sv">Testplats för exampleService (ExampleOrg).</mdui:Description>
+        <mdui:Description xml:lang="en">Test site for exampleService (ExampleOrg).</mdui:Description>
+        <mdui:InformationURL xml:lang="en">https://www.example.com/services/sakerhet/exampleservice/</mdui:InformationURL>
+        <mdui:InformationURL xml:lang="sv">https://www.example.com/services/sakerhet/exampleservice/</mdui:InformationURL>
+        <mdui:PrivacyStatementURL xml:lang="sv">https://wiki.example.com/display/info/exampleService+Privacy+Policy?showLanguage=sv_SE</mdui:PrivacyStatementURL>
+        <mdui:PrivacyStatementURL xml:lang="en">https://wiki.example.com/display/info/exampleService+Privacy+Policy?showLanguage=en_GB</mdui:PrivacyStatementURL>
+      </mdui:UIInfo>
+      <init:RequestInitiator Binding="urn:oasis:names:tc:SAML:profiles:SSO:request-init" Location="https://example.com/Shibboleth.sso/Login"/>
+      <idpdisc:DiscoveryResponse Binding="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol" Location="https://example.com/Shibboleth.sso/Login" index="1"/>
+
+
+<ti:TrustInfo xmlns:ti="urn:oasis:names:tc:SAML:metadata:trustinfo">
+   <ti:TrustProfile name="customer" strict="true">
+     <ti:DisplayName xml:lang="en">Customer Access</ti:DisplayName>
+     <ti:DisplayName xml:lang="sv">Kundinloggning</ti:DisplayName>
+     <ti:FallbackHandler profile="href">https://www.example.org/about</ti:FallbackHandler>
+     <ti:TrustedEntity>https://example.org/idp.xml</ti:TrustedEntity>
+     <ti:TrustedEntities match="registrationAuthority">http://www.swamid.se/</ti:TrustedEntities>
+   </ti:TrustProfile>
+</ti:TrustInfo>
+    </md:Extensions>
+
+    <md:KeyDescriptor use="signing">
+      <ds:KeyInfo>
+        <ds:KeyName>example.com</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509SubjectName>CN=example.com</ds:X509SubjectName>
+          <ds:X509Certificate>MIIEMjCCApqgAwIBAgIULYfaz0a2vQPUNhHOpqJiw+XMn6owDQYJKoZIhvcNAQEL
+BQAwKzEpMCcGA1UEAxMgdGVzdC1lZHVzaWduLmVkLWludGVncmF0aW9ucy5jb20w
+HhcNMjEwNjE4MDkyMzM0WhcNMzEwNjE2MDkyMzM0WjArMSkwJwYDVQQDEyB0ZXN0
+LWVkdXNpZ24uZWQtaW50ZWdyYXRpb25zLmNvbTCCAaIwDQYJKoZIhvcNAQEBBQAD
+ggGPADCCAYoCggGBAOcHd/seqF7Ki8bqzJSahdUETdIacXidbu9PA6kEUJ4d1IDt
+3jJCzmW8x0+T7n1RA5a2JAmbn9HOPoi3HgKEkxDDMbabODiNntZC4v+bQiMlB7UG
+LxF8UCX8gSgVHeyQPNx6NAnpmft+JZPts90wQBuRfarSz//oyhKRFYgGZ79D4cUP
+CqHZ6ZqmxwtZlujSULN8ePpcp5aMHp9pglHawgVmb340jlk2/jeFxkDNtTVXb6Ox
+0/NJeZN4P99uGNviiS83lI2VDZqSdW5Wx6vVsRRHpNpIQB5xoOktCQDQsMBTXlwQ
+aAaNQKUTh8bwvMLD6bXKsHBGA0hYEL9pSu8BhABcJzty+97LlkOFLijByeLu5b1y
+qzmd4Mo+l2t5vdeSiHeAFVR66scwPoMaiUpYbts6NtKWh8i2WjkpqIuLIgTJUzRr
+luhdsJZnvQkdCweCOVg5Aaittqh/UgRGQZ1RhsjOY2tDMpNcs5dmKzjkdC5nXQTo
+PUadahgVLW3zRIxVcwIDAQABo04wTDArBgNVHREEJDAigiB0ZXN0LWVkdXNpZ24u
+ZWQtaW50ZWdyYXRpb25zLmNvbTAdBgNVHQ4EFgQUg/YnxJdS6cW0SM9h85PTNfAp
+3pQwDQYJKoZIhvcNAQELBQADggGBAMykG0VJmjHQu/kp3kWFEHJDJfRiuWqAfm8k
+i8skRKDr2Bng93g5LD5P6YTp6S3HCGYo4sh3LCjlzrcjUAetOnKS4clzdMGwT3et
+ijCfrNrLkfA0GtkbjDmVI4gZFwnDZ7ABRmvM9ncc9UM4suTbl/VKHbRNQuUnhvnK
+LGxLgwhFbDmTAGtf7LGiOjo4QpdP1ujMRWv+l+cjipr5X6gqteH1Uj0wP2tcyL1f
+Tdv5I+YEGafA76R6e2iNP0ify+NkaJ9mnhUJXKXbHRvarV5fp9Nzoo47npgUegFo
+ihd3vAEmAtmfGKXsVkWE1AtRlPbwrCJSAeadGTa66H0omDB14M6vEQs7L9jbgw03
+S3mV8N25rwbce1luo6MUnPJpDc6iOnadnBeQ2LIXbhNj3Z6E1exadzNX9BUTxr68
+8rY8wHtadr+9xh/5mNnFuDKdn9ZciDjP9b3OjQH0fG/iJhZWF2DgZlSaCzR5qLAA
+YJIFVUg+VwfF8XvjH0WKszSmYywVYg==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </md:KeyDescriptor>
+    <md:KeyDescriptor use="encryption">
+      <ds:KeyInfo>
+        <ds:KeyName>example.com</ds:KeyName>
+        <ds:X509Data>
+          <ds:X509SubjectName>CN=example.com</ds:X509SubjectName>
+          <ds:X509Certificate>MIIEMjCCApqgAwIBAgIULYfaz0a2vQPUNhHOpqJiw+XMn6owDQYJKoZIhvcNAQEL
+BQAwKzEpMCcGA1UEAxMgdGVzdC1lZHVzaWduLmVkLWludGVncmF0aW9ucy5jb20w
+HhcNMjEwNjE4MDkyMzM0WhcNMzEwNjE2MDkyMzM0WjArMSkwJwYDVQQDEyB0ZXN0
+LWVkdXNpZ24uZWQtaW50ZWdyYXRpb25zLmNvbTCCAaIwDQYJKoZIhvcNAQEBBQAD
+ggGPADCCAYoCggGBAOcHd/seqF7Ki8bqzJSahdUETdIacXidbu9PA6kEUJ4d1IDt
+3jJCzmW8x0+T7n1RA5a2JAmbn9HOPoi3HgKEkxDDMbabODiNntZC4v+bQiMlB7UG
+LxF8UCX8gSgVHeyQPNx6NAnpmft+JZPts90wQBuRfarSz//oyhKRFYgGZ79D4cUP
+CqHZ6ZqmxwtZlujSULN8ePpcp5aMHp9pglHawgVmb340jlk2/jeFxkDNtTVXb6Ox
+0/NJeZN4P99uGNviiS83lI2VDZqSdW5Wx6vVsRRHpNpIQB5xoOktCQDQsMBTXlwQ
+aAaNQKUTh8bwvMLD6bXKsHBGA0hYEL9pSu8BhABcJzty+97LlkOFLijByeLu5b1y
+qzmd4Mo+l2t5vdeSiHeAFVR66scwPoMaiUpYbts6NtKWh8i2WjkpqIuLIgTJUzRr
+luhdsJZnvQkdCweCOVg5Aaittqh/UgRGQZ1RhsjOY2tDMpNcs5dmKzjkdC5nXQTo
+PUadahgVLW3zRIxVcwIDAQABo04wTDArBgNVHREEJDAigiB0ZXN0LWVkdXNpZ24u
+ZWQtaW50ZWdyYXRpb25zLmNvbTAdBgNVHQ4EFgQUg/YnxJdS6cW0SM9h85PTNfAp
+3pQwDQYJKoZIhvcNAQELBQADggGBAMykG0VJmjHQu/kp3kWFEHJDJfRiuWqAfm8k
+i8skRKDr2Bng93g5LD5P6YTp6S3HCGYo4sh3LCjlzrcjUAetOnKS4clzdMGwT3et
+ijCfrNrLkfA0GtkbjDmVI4gZFwnDZ7ABRmvM9ncc9UM4suTbl/VKHbRNQuUnhvnK
+LGxLgwhFbDmTAGtf7LGiOjo4QpdP1ujMRWv+l+cjipr5X6gqteH1Uj0wP2tcyL1f
+Tdv5I+YEGafA76R6e2iNP0ify+NkaJ9mnhUJXKXbHRvarV5fp9Nzoo47npgUegFo
+ihd3vAEmAtmfGKXsVkWE1AtRlPbwrCJSAeadGTa66H0omDB14M6vEQs7L9jbgw03
+S3mV8N25rwbce1luo6MUnPJpDc6iOnadnBeQ2LIXbhNj3Z6E1exadzNX9BUTxr68
+8rY8wHtadr+9xh/5mNnFuDKdn9ZciDjP9b3OjQH0fG/iJhZWF2DgZlSaCzR5qLAA
+YJIFVUg+VwfF8XvjH0WKszSmYywVYg==</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes192-gcm"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes192-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#tripledes-cbc"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep"/>
+      <md:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"/>
+    </md:KeyDescriptor>
+    <md:ArtifactResolutionService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.com/Shibboleth.sso/Artifact/SOAP" index="1"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:SOAP" Location="https://example.com/Shibboleth.sso/SLO/SOAP"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.com/Shibboleth.sso/SLO/Redirect"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/Shibboleth.sso/SLO/POST"/>
+    <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/Shibboleth.sso/SLO/Artifact"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/Shibboleth.sso/SAML2/POST" index="1"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact" Location="https://example.com/Shibboleth.sso/SAML2/Artifact" index="3"/>
+    <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:PAOS" Location="https://example.com/Shibboleth.sso/SAML2/ECP" index="4"/>
+    <md:AttributeConsumingService index="1">
+      <md:ServiceName xml:lang="en">exampleService (ExampleOrg)</md:ServiceName>
+      <md:ServiceName xml:lang="sv">exampleService (ExampleOrg)</md:ServiceName>
+      <md:RequestedAttribute FriendlyName="eduPersonPrincipalName" Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.6" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+      <md:RequestedAttribute FriendlyName="mail" Name="urn:oid:0.9.2342.19200300.100.1.3" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+      <md:RequestedAttribute FriendlyName="displayName" Name="urn:oid:2.16.840.1.113730.3.1.241" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+      <md:RequestedAttribute FriendlyName="givenName" Name="urn:oid:2.5.4.42" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+      <md:RequestedAttribute FriendlyName="sn" Name="urn:oid:2.5.4.4" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+      <md:RequestedAttribute FriendlyName="mailLocalAddress" Name="urn:oid:2.16.840.1.113730.3.1.13" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>
+    </md:AttributeConsumingService>
+  </md:SPSSODescriptor>
+  <md:Organization>
+    <md:OrganizationName xml:lang="en">ExampleOrg</md:OrganizationName>
+    <md:OrganizationName xml:lang="sv">ExampleOrg</md:OrganizationName>
+    <md:OrganizationDisplayName xml:lang="en">ExampleOrg</md:OrganizationDisplayName>
+    <md:OrganizationDisplayName xml:lang="sv">ExampleOrg</md:OrganizationDisplayName>
+    <md:OrganizationURL xml:lang="en">https://example.com</md:OrganizationURL>
+    <md:OrganizationURL xml:lang="sv">https://example.com</md:OrganizationURL>
+  </md:Organization>
+  <md:ContactPerson contactType="technical">
+    <md:GivenName>John</md:GivenName>
+    <md:EmailAddress>mailto:john@example.com</md:EmailAddress>
+  </md:ContactPerson>
+  <md:ContactPerson contactType="administrative">
+    <md:GivenName>John</md:GivenName>
+    <md:EmailAddress>mailto:john@example.com</md:EmailAddress>
+  </md:ContactPerson>
+  <md:ContactPerson contactType="support">
+    <md:GivenName>John</md:GivenName>
+    <md:EmailAddress>mailto:john@example.com</md:EmailAddress>
+  </md:ContactPerson>
+  <md:ContactPerson xmlns:remd="http://refeds.org/metadata" contactType="other" remd:contactType="http://refeds.org/metadata/contactType/security">
+    <md:GivenName>John</md:GivenName>
+    <md:EmailAddress>mailto:john@example.com</md:EmailAddress>
+  </md:ContactPerson>
+</md:EntityDescriptor>

--- a/src/pyff/test/test_pipeline.py
+++ b/src/pyff/test/test_pipeline.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import tempfile
@@ -708,3 +709,36 @@ class SigningTest(PipeLineTest):
         except ValueError:
             pass
         assert "Expected exception from bad namespace in"
+
+
+    def test_tinfojson(self):
+        with patch.multiple("sys", exit=self.sys_exit, stdout=StreamCapturing(sys.stdout)):
+            tmpdir = tempfile.mkdtemp()
+            os.rmdir(tmpdir)  # lets make sure 'store' can recreate it
+            try:
+                self.exec_pipeline("""
+- load:
+   - file://%s/metadata/test02-sp.xml
+- select
+- tinfojson
+- publish:
+    output: %s/tinfo.json
+    raw: true
+    update_store: false
+""" % (self.datadir, tmpdir))
+                fn = "%s/tinfo.json" % tmpdir
+                assert os.path.exists(fn)
+                with open(fn, 'r') as f:
+                    tinfo_json = json.load(f)
+
+                assert 'https://example.com.com/shibboleth' in tinfo_json
+                example_tinfo = tinfo_json['https://example.com.com/shibboleth']
+                assert 'customer' in example_tinfo['profiles']
+                customer_tinfo = example_tinfo['profiles']['customer']
+                assert customer_tinfo['entity'][0] == {'entity_id': 'https://example.org/idp.xml', 'include': True}
+                assert customer_tinfo['entities'][0] == {'select': 'http://www.swamid.se/', 'match': 'registrationAuthority', 'include': True}
+                assert customer_tinfo['fallback_handler'] == {'profile': 'href', 'handler': 'https://www.example.org/about'}
+            except IOError:
+                pass
+            finally:
+                shutil.rmtree(tmpdir)


### PR DESCRIPTION
### All Submissions:

* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ ] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [ ] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?

* I have only updated the lunr indexer (not the redis one).
* The lunr indexer now has 2 more indexes: registrationAuthority and
   entityID.
* The search for the lunr indexer is more complex now: instead of looking
   for full text presence in all the indexes, it is possible to indicate
   which indexes to look in, and whether to include or exclude the matches.
* In addition to the JSON for the list of IdPs, the app now loads a JSON
   with the trust info, and keeps it in a dict / object keyed by (SP)
   entityID.
* In the search requests, apart from the q param, we can add 2 more
   params, entityID and trustProfile. With these, we get the corresponding
   trust info and use it to filter the list of IdPs.