### PR TITLE
Parsecopy

### DIFF
--- a/src/pyff/test/test_pipeline.py
+++ b/src/pyff/test/test_pipeline.py
@@ -708,3 +708,21 @@ class SigningTest(PipeLineTest):
         except ValueError:
             pass
         assert "Expected exception from bad namespace in"
+
+    def test_parsecopy_(self):
+        entity = 'https://idp.example.com/saml2/idp/metadata.php'
+        res, md = self.exec_pipeline(
+            f"""
+- when batch:
+    - load:
+        - {self.datadir}/metadata/test01.xml
+- map:
+     - fork:
+       - publish:
+"""
+        )
+        assert "Expected exception from bad namespace in"
+        assert md.lookup(entity)
+
+
+


### PR DESCRIPTION
Due to a hard to find bug, fork which uses deepcopy can lose some namespaces. The parsecopy argument is a workaround. It uses a brute force serialisation and deserialisation to get around the bug.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [X] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


