### PR TITLE
add DiscoveryResponse info to SPs in discojson

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -171,3 +171,6 @@ to sign using HSMs. The only mandatory non-python dependency now is lxml.
 * Fix random seeding
 * Fix for data handling related to non-Z timezones in metadata
 
+2.1.3
+-----
+* Add DiscoveryResponse info to SPs in discojson

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -37,6 +37,7 @@ NS = dict(
     ser="http://eidas.europa.eu/metadata/servicelist",
     eidas="http://eidas.europa.eu/saml-extensions",
     ti="https://seamlessaccess.org/NS/trustinfo",
+    idpdisc="urn:oasis:names:tc:SAML:profiles:SSO:idp-discovery-protocol",
 )
 
 #: These are the attribute aliases pyFF knows about. These are used to build URI paths, populate the index

--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -783,6 +783,14 @@ def registration_authority(entity):
         return regauth_el.attrib.get('registrationAuthority')
 
 
+def discovery_responses(entity):
+    responses = None
+    responses_els = entity.findall(".//{%s}DiscoveryResponse" % NS['idpdisc'])
+    if len(responses_els) > 0:
+        responses = [el.attrib.get('Location') for el in responses_els]
+    return responses
+
+
 def entity_extended_display(entity, langs=None):
     """Utility-method for computing a displayable string for a given entity.
 
@@ -875,6 +883,7 @@ def discojson(e, sources=None, langs=None, fallback_to_favicon=False, icon_store
     categories = entity_attribute(e, "http://macedir.org/entity-category")
     certifications = entity_attribute(e, "urn:oasis:names:tc:SAML:attribute:assurance-certification")
     cat_support = entity_attribute(e, "http://macedir.org/entity-category-support")
+    disc_responses = discovery_responses(e)
 
     d = dict(
         title=title,
@@ -899,6 +908,9 @@ def discojson(e, sources=None, langs=None, fallback_to_favicon=False, icon_store
 
     if sources is not None:
         d['md_source'] = sources
+
+    if disc_responses is not None:
+        d["discovery_responses"] = disc_responses
 
     eattr = entity_attribute_dict(e)
     if 'idp' in eattr[ATTRS['role']]:


### PR DESCRIPTION
### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


This adds a `discovery_responses` key in the JSON produced by discojson  for the SP entities that have DiscoveryResponse elements in their metadata.

This is to allow SeamlessAccess to warn users when they are sent to SeamlessAccess with a return URL that does not match the DiscoveryResponse elements published in the SP metadata.