### PR TITLE
Update constants.py to allow -v to work

### DIFF
--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -536,7 +536,7 @@ def parse_options(program, docs):
             if o in ('-h', '--help'):
                 print(docs)
                 sys.exit(0)
-            elif o in ('--version',):
+            elif o in ('-v', '--version'):
                 print("{} version {}".format(program, pyff_version))
                 sys.exit(0)
             elif o in ('-A', '--alias'):


### PR DESCRIPTION
trivial fix to a bug. for years the argument of -h has said that you can use -v or --version to print the version of pyFF - well, now you can

### All Submissions:

* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ x ] Have you added an explanation of what problem you are trying to solve with this PR?
* [ x ] Have you added information on what your changes do and why you chose this as your solution?
* [ - ] Have you written new tests for your changes?
* [ x ] Does your submission pass tests?
* [ x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


