### PR TITLE
Fix invalid parsing of the bool arguments

### DIFF
--- a/src/pyff/test/test_parse_options.py
+++ b/src/pyff/test/test_parse_options.py
@@ -1,0 +1,28 @@
+import sys
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from pyff.constants import parse_options, config
+
+
+class TestParseOptions(TestCase):
+
+    def test_bool_long_spec_setting(self):
+        test_args = ["pyffd", "--devel_memory_profile", "--foreground"]
+
+        with patch.object(sys, 'argv', test_args):
+            parse_options("pyffd", "Additional help.")
+
+        self.assertTrue(config.devel_memory_profile)
+        self.assertTrue(config.foreground)
+        self.assertFalse(config.daemonize)
+
+    def test_inverted_setting_short_spec(self):
+        test_args = ["pyffd", "-C"]
+
+        with patch.object(sys, 'argv', test_args):
+            parse_options("pyffd", "Additional help.")
+
+        self.assertTrue(config.no_caching)
+        self.assertFalse(config.caching_enabled)


### PR DESCRIPTION
This MR aims to fix the a couple of issues in the argument parsing:

1. `InvertedSetting` incorrectly defines its own `__get__` and `__set__` dunder methods.
2. Boolean arguments are not properly initialized.
3. `daemonize` is missing `typeconv` setting.

I have found all these issues (and a few more) while trying to deploy `pyff` on our infra at CERN.

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [x] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


