### PR TITLE
Fixes for python 3.11

### DIFF
--- a/src/pyff/i18n.py
+++ b/src/pyff/i18n.py
@@ -31,5 +31,4 @@ else:
 
 gettext.find(APP_NAME, mo_location)
 gettext.textdomain(APP_NAME)
-gettext.bind_textdomain_codeset(APP_NAME, "UTF-8")
 language = gettext.translation(APP_NAME, mo_location, languages=languages, fallback=True)

--- a/src/pyff/repo.py
+++ b/src/pyff/repo.py
@@ -15,7 +15,7 @@ class MDRepository():
     """
 
     def __init__(self, scheduler=None):
-        random.seed(self)
+        random.seed()
         self.rm = Resource()  # root
         if scheduler is None:
             scheduler = make_default_scheduler()


### PR DESCRIPTION
This PR updates the last 1.x release containing an integrated discovery to be compatible with python 3.11, so it can be `pip installed` on a Debian Bookworm machine. This helps us deploying our test environment.
