### PR TITLE
fix: search_handler yields bytes and handle None in entity_extended_d…

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -462,7 +462,7 @@ def search_handler(request: Request) -> Response:
         for e in entities:
             if in_loop:
                 yield b','
-            yield dumps(e)
+            yield dumps(e).encode('utf-8')
             in_loop = True
         yield b']'
 

--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -841,7 +841,7 @@ def entity_extended_display(entity, langs=None):
     if info == entity.get('entityID'):
         info = ''
 
-    return display.strip(), info.strip()
+    return (display or '').strip(), (info or '').strip()
 
 
 def entity_display_name(entity: Element, langs=None) -> str:


### PR DESCRIPTION
fix: search_handler yields bytes and handle None in entity_extended_display

- search_handler yielded str from dumps() instead of bytes, causing TypeError in gunicorn when streaming search results
- entity_extended_display could return None for display/info causing AttributeError on .strip() when searching for SPs

Tested on pyFF 2.1.5 with gunicorn 25.1.0 and Python 3.12

### All Submissions:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what problem you are trying to solve with this PR?
* [x] Have you added information on what your changes do and why you chose this as your solution?
* [] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [x] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


