### PR TITLE
new: add map_threads option for ThreadPool size in map pipe

### DIFF
--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -22,7 +22,7 @@ from lxml import etree
 from lxml.etree import DocumentInvalid
 from str2bool import str2bool
 
-from pyff.constants import NS
+from pyff.constants import NS, config
 from pyff.decorators import deprecated
 from pyff.exceptions import MetadataException
 from pyff.logs import get_log
@@ -111,7 +111,7 @@ def _map(req: Plumbing.Request, *opts):
 
     from multiprocessing.pool import ThreadPool
 
-    pool = ThreadPool()
+    pool = ThreadPool(config.map_threads)
     result = pool.map(_p, iter_entities(req.t), chunksize=10)
     log.info(f"processed {len(result)} entities")
 

--- a/src/pyff/constants.py
+++ b/src/pyff/constants.py
@@ -344,6 +344,10 @@ class Config:
         "info_buffer_size", default=10, typeconv=as_int, info="how much history to keep about each metadata URL"
     )
 
+    map_threads = S(
+        "map_threads", typeconv=as_int, info="how many threads to create in map pipe [default: os.process_cpu_count() ]"
+    )
+
     worker_pool_size = S(
         "worker_pool_size", default=1, cmdline=['pyffd'], typeconv=as_int, info="how many gunicorn workers to run"
     )


### PR DESCRIPTION
Allow configuring ThreadPool size used in map pipe.

Passing default value None makes ThreadPool use os.process_cpu_count(), keeping existing behaviour.

Setting the value to 1 provides a workaround for #315 (avoid parallelism).

Given that most processing happens withing Python without releasing GIL, it actually does not incur any significant penalty.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [ ] Have you written new tests for your changes?
* [x] Does your submission pass tests?
* [ ] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


