### PR TITLE
fix: use quote instead of quote_plus

### DIFF
--- a/src/pyff/api.py
+++ b/src/pyff/api.py
@@ -4,7 +4,7 @@ from collections.abc import Generator, Iterable, Mapping
 from datetime import datetime, timedelta
 from json import dumps
 from typing import Any, Optional
-from urllib.parse import quote_plus
+from urllib.parse import quote
 
 import pyramid.httpexceptions as exc
 import pytz
@@ -395,7 +395,7 @@ def webfinger_handler(request: Request) -> Response:
     aliases = request.registry.aliases
     for a in aliases.keys():
         for v in request.registry.md.store.attribute(aliases[a]):
-            _links(f'{a}/{quote_plus(v)}')
+            _links(f'{a}/{quote(v)}')
 
     response = Response(dumps(jrd, default=json_serializer))
     response.headers['Content-Type'] = 'application/json'

--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from datetime import datetime
 from io import BytesIO
 from typing import Optional
-from urllib.parse import quote_plus, urlparse
+from urllib.parse import quote, urlparse
 
 import xmlsec
 from lxml import etree
@@ -539,7 +539,7 @@ def publish(req: Plumbing.Request, *opts):
 
     enc = _nop
     if req.args.get('urlencode_filenames'):
-        enc = quote_plus
+        enc = quote
 
     if output_file is None:
         return req.t


### PR DESCRIPTION
MDQ spec explicitly asks for spaces to be encoded as `%20`, not `+`

This is achieved by `urllib.parse.quote` - the only difference `quote_plus` brings is it would be encoding spaces as `+`:
https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote_plus

While entityIDs cannot really contain spaces (not permitted in an URI), this is all just a technicality, but quote is the correct function to use.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [N/A] Have you written new tests for your changes?
* [X] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


