### PR TITLE
fix: builtins/publish: keep xs+xsi NS in cleanup

### DIFF
--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -554,7 +554,10 @@ def publish(req: Plumbing.Request, *opts):
 
     # clean unused namespaces - the working document isn't always XML (eg discojson* produce JSON)
     if isinstance(data, (etree._Element, etree._ElementTree)):
-        etree.cleanup_namespaces(data)
+        # Keep xs: and xsi:, as these are crucial - and xs: is used only
+        # in attribute values, so may appear as unused.
+        keep_ns_prefixes = ['xs', 'xsi']
+        etree.cleanup_namespaces(data, keep_ns_prefixes=keep_ns_prefixes)
 
     if not req.args.get('raw'):
         data = dumptree(req.t, pretty_print=req.args.get('pretty_print'))

--- a/src/pyff/builtins.py
+++ b/src/pyff/builtins.py
@@ -552,13 +552,6 @@ def publish(req: Plumbing.Request, *opts):
     out = output_file
     data = req.t
 
-    # clean unused namespaces - the working document isn't always XML (eg discojson* produce JSON)
-    if isinstance(data, (etree._Element, etree._ElementTree)):
-        # Keep xs: and xsi:, as these are crucial - and xs: is used only
-        # in attribute values, so may appear as unused.
-        keep_ns_prefixes = ['xs', 'xsi']
-        etree.cleanup_namespaces(data, keep_ns_prefixes=keep_ns_prefixes)
-
     if not req.args.get('raw'):
         data = dumptree(req.t, pretty_print=req.args.get('pretty_print'))
 

--- a/src/pyff/samlmd.py
+++ b/src/pyff/samlmd.py
@@ -488,6 +488,12 @@ def entitiesdescriptor(
             ent_insert = deepcopy(ent_insert)
         t.append(ent_insert)
 
+    # clean unused namespaces
+    # Keep xs: and xsi:, as these are crucial - and xs: is used only
+    # in attribute values, so may appear as unused.
+    keep_ns_prefixes = ['xs', 'xsi']
+    etree.cleanup_namespaces(t, keep_ns_prefixes=keep_ns_prefixes)
+
     if config.devel_write_xml_to_file:
         import os
 


### PR DESCRIPTION
Fixes #333

The `lxml.etree.cleanup_namespaces` function only considers namespaces used in XML Element and Attribute names, but not in attribute values.  The `xs` namespace is used only in values of `xsi:type` attributes and is thus not considered as used by LXML, and would get removed.

Keep it explicitly to avoid creating invalid metadata.

### All Submissions:

* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [X] Have you added an explanation of what problem you are trying to solve with this PR?
* [X] Have you added information on what your changes do and why you chose this as your solution?
* [NotYet] Have you written new tests for your changes?
* [N/A] Does your submission pass tests?
* [X] This project follows PEP8 style guide. Have you run your code against the 'flake8' linter?


